### PR TITLE
V1.0.2 (#5)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.{cs,vb}]
+
+# IDE0003: Remove qualification
+dotnet_diagnostic.IDE0003.severity = none

--- a/MG.Collections-DotNet5/MG.Collections-NET5.csproj
+++ b/MG.Collections-DotNet5/MG.Collections-NET5.csproj
@@ -7,8 +7,8 @@
     <Authors>Mike Garvey</Authors>
     <Company>Yevrag35, LLC.</Company>
     <Copyright>Copyright © 2021 Yevrag35, LLC.  All rights reserved.</Copyright>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
-    <FileVersion>1.0.1</FileVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+    <FileVersion>1.0.2</FileVersion>
     <AssemblyName>MG.Collections</AssemblyName>
 	<Product>MG.Collections .NET5</Product>
 	<AssemblyTitle>
@@ -17,7 +17,7 @@
 	<PackageProjectUrl>https://github.com/Yevrag35/ExpandedCollections</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/Yevrag35/ExpandedCollections.git</RepositoryUrl>
 	<RepositoryType>Git</RepositoryType>
-	<Version>1.0.1</Version>
+	<Version>1.0.2</Version>
 	<Description>A library consisting of specialized collection classes.</Description>
 	<PackageIcon>Collections_Red.png</PackageIcon>
 	<PackageIconUrl />
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Include="E:\Local_Repos\MG.Collections\assets\Collections_Red.png">
+	  <None Include="..\assets\Collections_Red.png">
 	    <Pack>True</Pack>
 	    <PackagePath></PackagePath>
 	  </None>

--- a/MG.Collections-DotNet5/MG.Collections.xml
+++ b/MG.Collections-DotNet5/MG.Collections.xml
@@ -4,6 +4,842 @@
         <name>MG.Collections</name>
     </assembly>
     <members>
+        <member name="T:MG.Collections.Classes.ListCollection`1">
+            <summary>
+            An indentical implementation to <see cref="T:System.Collections.Generic.List`1"/> but with the ability for derived classes to override
+            the Add, Insert, Set, and Remove methods.  Similar to the way <see cref="T:System.Collections.ObjectModel.Collection`1"/>
+            allows.
+            </summary>
+            <typeparam name="T">The type of elements in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.</typeparam>
+        </member>
+        <member name="E:MG.Collections.Classes.ListCollection`1.Reversed">
+            <summary>
+            An event that occurs when the <see cref="T:MG.Collections.Classes.ListCollection`1"/> is reversed through the 'Reverse' methods.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Classes.ListCollection`1.Sorted">
+            <summary>
+            An event that occurs when the <see cref="T:MG.Collections.Classes.ListCollection`1"/> is sorted through the 'Sort' methods.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Classes.ListCollection`1.Item(System.Int32)">
+            <summary>
+            Gets or sets the element at the specified index.
+            </summary>
+            <param name="index">The index value for zero-based indexing.</param>
+            <returns>
+                The element at the specified index.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0
+                -or-
+                <paramref name="index"/> is greater than or equal than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+        </member>
+        <member name="P:MG.Collections.Classes.ListCollection`1.Capacity">
+            <summary>
+            Gets or sets the total number of elements the internal data structure can hold without resizing.
+            </summary>
+            <returns>
+                The number of elements that the <see cref="T:MG.Collections.Classes.ListCollection`1"/> can contain before resizing is required.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <see cref="P:MG.Collections.Classes.ListCollection`1.Capacity"/> is set to a value that is less than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+            <exception cref="T:System.OutOfMemoryException">
+                There is not enough memory available on the system.
+            </exception>
+        </member>
+        <member name="P:MG.Collections.Classes.ListCollection`1.Count">
+            <summary>
+            Gets the number of elements contained in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <returns>
+                The number of elements contained in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor">
+            <summary>
+            The default constructor.  Initializes an empty <see cref="T:MG.Collections.Classes.ListCollection`1"/> with the default capacity.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor(System.Int32)">
+            <summary>
+            Initializes an empty <see cref="T:MG.Collections.Classes.ListCollection`1"/> with the specified capacity.
+            </summary>
+            <param name="capacity">The number of elements that the new collection can initially store.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Initializes a new <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance that contains elements copied from the specified
+            collection and has sufficient capacity to accomodate the number of elements copied.
+            </summary>
+            <remarks>
+                If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance is initialized.
+            </remarks>
+            <param name="items">
+                The collection whose elements will be copied to the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor(System.Collections.Generic.IEnumerable{`0},System.Boolean)">
+            <summary>
+            Initializes a new <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance that contains elements copied from the specified
+            collection and has sufficient capacity to accomodate the number of elements copied.  It also provides an option to
+            initialize the collection even if <paramref name="items"/> is <see langword="null"/>.
+            </summary>
+            <remarks>
+                If <paramref name="items"/> is null and <paramref name="initializeIfNull"/> is 
+                <see langword="false"/>, an <see cref="T:System.ArgumentNullException"/> exception is thrown.  If, however,
+                <paramref name="initializeIfNull"/> is <see langword="true"/>, an empty
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance is initialized with the default capacity instead.
+            </remarks>
+            <param name="items">
+                The collection whose elements will be copied to the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </param>
+            <param name="initializeIfNull">
+                Indicates that the <see cref="T:MG.Collections.Classes.ListCollection`1"/> should be initialized even if <paramref name="items"/>
+                is found to be <see langword="null"/>.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="initializeIfNull"/> is <see langword="false"/> and
+                <paramref name="items"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Add(`0)">
+            <summary>
+            Adds an item to the end of the collection.
+            </summary>
+            <param name="item">The object to be added to the end of the collection.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Clear">
+            <summary>
+            Removes all elements from the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Contains(`0)">
+            <summary>
+            Determines whether an element is in the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+            <param name="item">
+            The object to locate in the <see cref="T:MG.Collections.UniqueListBase`1"/>.  The value can be null for reference types.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.CopyTo(`0[],System.Int32)">
+            <summary>
+            Copies the entire <see cref="T:MG.Collections.UniqueListBase`1"/> to a compatible one-dimensional array, starting at
+            the specified index of the target array.
+            </summary>
+            <param name="array">
+            The one-dimensional array that is the destination of the elements copied from
+            <see cref="T:MG.Collections.UniqueListBase`1"/>.  The array must have zero-based indexing.
+            </param>
+            <param name="arrayIndex">The zero-based index in the target array at which copying begins.</param>
+            <exception cref="T:System.ArgumentNullException"/>
+            <exception cref="T:System.ArgumentOutOfRangeException"/>
+            <exception cref="T:System.ArgumentException"/>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.IndexOf(`0)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the first occurrence
+            within the entire <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+            <param name="item">The object to locate in the <see cref="T:MG.Collections.UniqueListBase`1"/>.  The value can be null for reference types.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Remove(`0)">
+            <summary>
+            Removes the specific object from the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+            <param name="item">
+                The object to remove from the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ToArray">
+            <summary>
+            Copies the elements of the <see cref="T:MG.Collections.UniqueList`1"/> to a new array.
+            </summary>
+            <returns>
+                An array containing copies of the elements of the <see cref="T:MG.Collections.UniqueList`1"/>.  If the list contains no elements, 
+                an empty array is returned.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.TrueForAll(System.Func{`0,System.Boolean})">
+            <summary>
+            Determines whether every element in the <see cref="T:MG.Collections.ReadOnlyList`1"/> matches the conditions
+            defined by the specified predicate.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate that defines the conditions to check against the elements.</param>
+            <returns>
+                <see langword="true"/>: if every element in the list matches the conditions defined; 
+                otherwise, <see langword="false"/>.
+                If the list has no elements, the return value is <see langword="true"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.BinarySearch(`0)">
+            <summary>
+            Searches the entire sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/> for an element using the default comparer
+            and returns the zero-based index of the element.
+            </summary>
+            <param name="item">The object to locate.  The value can be <see langword="null"/> for reference types.</param>
+            <returns>
+                The zero-based index of <paramref name="item"/> in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>,
+                if <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement
+                of the index of the next element that is larger than <paramref name="item"/> or, if there is no
+                larger element, the bitwise complement of <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                The default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find
+                an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.BinarySearch(`0,System.Collections.Generic.IComparer{`0})">
+            <summary>
+            Searches the entire sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/> for an element using the specified comparer and
+            returns the zero-based index of the elements.
+            </summary>
+            <param name="item">The object to locate.  The value can be <see langword="null"/> for reference types.</param>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements.
+                -or-
+                <see langword="null"/> to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <returns>
+                The zero-based index of <paramref name="item"/> in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>, if
+                <paramref name="item"/> is found; otherwise, a negative number that is bitwise complement of the index
+                of the next element that is larger than <paramref name="item"/> or, if there is no larger element, the
+                bitwise complement of <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> 
+                cannot find an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.BinarySearch(System.Int32,System.Int32,`0,System.Collections.Generic.IComparer{`0})">
+            <summary>
+                Searches a range of elements in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>
+                for an element using the specified comparer and returns the zero-based index
+                of the element.
+            </summary>
+            <param name="index">The zero-based starting index of the range to search.</param>
+            <param name="count">The length of the range to search.</param>
+            <param name="item">The object to locate. The value can be <see langword="null"/> for reference types.</param>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements.
+                -or-
+                <see langword="null"/> to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <returns>
+                The zero-based index of <paramref name="item"/> in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>, if
+                <paramref name="item"/> is found; otherwise, a negative number that is bitwise complement of the index
+                of the next element that is larger than <paramref name="item"/> or, if there is no larger element, the
+                bitwise complement of <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range in the
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> 
+                cannot find an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ConvertAll``1(System.Converter{`0,``0})">
+            <summary>
+            Converts the elements in the current <see cref="T:MG.Collections.Classes.ListCollection`1"/> to another
+                type, and returns a list containing the converted elements.
+            </summary>
+            <typeparam name="TOutput">
+                The type of the elements of the target array.
+            </typeparam>
+            <param name="converter">
+                A <see cref="T:System.Converter`2"/> delegate that converts each element from one type
+                to another type.
+            </param>
+            <returns>
+                A <see cref="T:System.Collections.Generic.List`1"/> of the target type containing the converted elements from the
+                current <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="converter"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.CopyTo(`0[])">
+            <summary>
+            Copies the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/> to a compatible one-dimensional array, starting at the
+            beginning of the target array.
+            </summary>
+            <param name="array">
+                The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/>.  The <see cref="T:System.Array"/> must have zero-based indexing.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                The number of elements in the source <see cref="T:MG.Collections.Classes.ListCollection`1"/> is greater than the number of
+                elements that the destination array can contain.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="array"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.CopyTo(System.Int32,`0[],System.Int32,System.Int32)">
+            <summary>
+            Copies a range of elements from the <see cref="T:MG.Collections.Classes.ListCollection`1"/> to a compatible one-dimensional array,
+            starting at the specified index of the target array.
+            </summary>
+            <param name="index">
+                The zero-based index in the source <see cref="T:MG.Collections.Classes.ListCollection`1"/> at which copying begins.
+            </param>
+            <param name="array">
+                The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/>.  The <see cref="T:System.Array"/> must have zero-based indexing.
+            </param>
+            <param name="arrayIndex">
+                The zero-based index in <paramref name="array"/> at which copying begins.
+            </param>
+            <param name="count">The number of elements to copy.</param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> is equal to or greater than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/> of the source <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+                -or-
+                The number of elements from <paramref name="index"/> to the end of the source <see cref="T:MG.Collections.Classes.ListCollection`1"/> is greater
+                than the available space from <paramref name="arrayIndex"/> to the end of the destination array.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="array"/> is <see langword="null"/>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ForEach(System.Action{`0})">
+            <summary>
+            Performs the specified action on each element of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="action">
+                The <see cref="T:System.Action`1"/> delegate to perform on each element of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.InvalidOperationException">
+                An element in the collection has been modified.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.InsertRange(System.Int32,System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Inserts the elements of a collection into the <see cref="T:MG.Collections.Classes.ListCollection`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which the new elements should be inserted.</param>
+            <param name="collection">
+                The collection whose elements should be insert into the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.  The collection
+                itself cannot be <see langword="null"/>, but it can contain elements that are <see langword="null"/>, if 
+                type <typeparamref name="T"/> is a reference type.
+            </param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveAll(System.Func{`0,System.Boolean})">
+            <summary>
+            Removes all the elements that match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">
+                The <see cref="T:System.Func`2"/> delegate that defines the conditions of the elements to remove.
+            </param>
+            <returns>
+                The number of elements removed from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="match"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveRange(System.Int32,System.Int32)">
+            <summary>
+            Removes a range of elements from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="index">The zero-based starting index of the range of elements to remove.</param>
+            <param name="count">The number of elements to remove.</param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements
+                in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.TrimExcess">
+            <summary>
+            Sets the capacity to the actual number of elements in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>,
+            if that number is less than a threshold value.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Exists(System.Func{`0,System.Boolean})">
+            <summary>
+                Determines whether the <see cref="T:MG.Collections.ReadOnlyList`1"/> contains elements that
+                match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">
+                The <see cref="T:System.Func`2"/> delegate that defines the conditions of the 
+                elements to search for.
+            </param>
+            <returns>
+            <see langword="true"/>:
+                if the <see cref="T:MG.Collections.ReadOnlyList`1"/> contains one or more elements that
+                <paramref name="match"/> defined.
+            <see langword="false"/>:
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Find(System.Func{`0,System.Boolean})">
+            <summary>
+                Searches for an element that matches the conditions defined by the specified
+                predicate, and returns the first occurrence within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">
+                The <see cref="T:System.Func`2"/> delegate that defines the conditions of the
+                elements to search for.
+            </param>
+            <returns>
+                The first element that matches the conditions if found; otherwise the default value for <typeparamref name="T"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindAll(System.Func{`0,System.Boolean})">
+            <summary>
+            Retrieves all of the elements that match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                An <see cref="T:System.Collections.Generic.List`1"/> containing all of the elements that match the conditions if found; 
+                otherwise, an empty list.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindIndex(System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+            index of the first occurrence within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the first occurrence of an element that matches the conditions defined
+                by <paramref name="match"/> if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindIndex(System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+            index of the first occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the 
+            specified index to the last element.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the first occurrence of an element that matches the conditions defined
+                by <paramref name="match"/> if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindIndex(System.Int32,System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+            index of the first occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that starts at the 
+            specified index and contains the specified number of elements.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the search.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the first occurrence of an element that matches the conditions defined
+                by <paramref name="match"/> if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section of the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLast(System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the last occurrence within the
+            entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The last elements that matches the conditions defined by the specified predicate, if found; otherwise, the default value for
+                type <typeparamref name="T"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLastIndex(System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+            lat occurrence within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the last occurrence of an element that matches the conditions defined by
+                <paramref name="match"/>, if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLastIndex(System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+            lat occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the first element to the 
+            specified index.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the backward search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the last occurrence of an element that matches the conditions defined by
+                <paramref name="match"/>, if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLastIndex(System.Int32,System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+            lat occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that contains the specified number
+            of elements and ends at the specified index.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the backward search.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the last occurrence of an element that matches the conditions defined by
+                <paramref name="match"/>, if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section of the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.GetRange(System.Int32,System.Int32)">
+            <summary>
+            Creates a shallow copy of a range of elements in the source <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="index">The zero-based index at which the range starts.</param>
+            <param name="count">The number of elements in the range.</param>
+            <returns>A shallow copy of a range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.</returns>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.IndexOf(`0,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the first occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the specified index to the last element.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the search.  0 (zero) is valid in an empty list.</param>
+            <returns>
+                The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.IndexOf(`0,System.Int32,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the first occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the specified index to the last element.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the search.  0 (zero) is valid in an empty list.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <returns>
+                The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="index"/> and <paramref name="count"/> do not specify a vliad section in the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.LastIndexOf(`0)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the last occurrence
+            within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <returns>
+                The zero-based index of the last occurrence of <paramref name="item"/> within the entire
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.LastIndexOf(`0,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the last occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the first element to the specified index.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the backward search.</param>
+            <returns>
+                The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.LastIndexOf(`0,System.Int32,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the last occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that contains the specified number
+            of elements and ends at the specified index.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the backward search.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <returns>
+                The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/> that contains <paramref name="count"/> number of elements and ends at
+                <paramref name="index"/>, if found; otherwise, -1;
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="index"/> and <paramref name="count"/> do not specify a vliad section in the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Reverse">
+            <summary>
+            Reverses the order of the elements in the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Reverse(System.Int32,System.Int32)">
+            <summary>
+            Reverses the order of the elements in the specified range.
+            </summary>
+            <param name="index">The zero-based starting index of the range to reverse.</param>
+            <param name="count">The number of elements in the range to reverse.</param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in 
+                the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Sort">
+            <summary>
+            Sorts the elements in the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/> using the default comparer.
+            </summary>
+            <exception cref="T:System.InvalidOperationException">
+                The default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the 
+                <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> interface for type 
+                <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Sort(System.Collections.Generic.IComparer{`0})">
+            <summary>
+            Sorts the elements in the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/> using the specified comparer.
+            </summary>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/> to use the default comparer
+                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                The implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+                <paramref name="comparer"/> might not return 0 when comparing an item with itself.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                The default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the 
+                <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> interface for type 
+                <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Sort(System.Int32,System.Int32,System.Collections.Generic.IComparer{`0})">
+            <summary>
+            Sorts the elements in a range of elements in <see cref="T:MG.Collections.Classes.ListCollection`1"/> using the specified comparer.
+            </summary>
+            <param name="index">The zero-based starting index of the range to sort.</param>
+            <param name="count">The length of the range to sort.</param>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/> to use the default comparer
+                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not specify a valid range in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+                -or-
+                The implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+                <paramref name="comparer"/> might not return 0 when comparing an item with itself.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> 
+                cannot find an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> 
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.GetEnumerator">
+            <summary>
+            Returns an enumerator that iterates through the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.System#Collections#IEnumerable#GetEnumerator">
+            <summary>
+            Returns an enumerator that iterates through the <see cref="T:System.Collections.IEnumerable"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Insert(System.Int32,`0)">
+            <summary>
+            Inserts an element into the <see cref="T:MG.Collections.Classes.ListCollection`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which item should be inserted.</param>
+            <param name="item">The object to insert. The value can be <see langword="null"/> for reference types.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.AddItem(`0)">
+            <summary>
+            Adds an object to the end of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="item">The object to add.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ClearItems">
+            <summary>
+            Removes all elements from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.InsertItem(System.Int32,`0)">
+            <summary>
+            Inserts an elements into the <see cref="T:MG.Collections.Classes.ListCollection`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which <paramref name="item"/> should be inserted.</param>
+            <param name="item">The object to insert.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveItem(`0)">
+            <summary>
+            Removes the specified element from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="item">The element to remove.</param>
+            <returns>
+                <see langword="true"/> if <paramref name="item"/> is successfully removed; otherwise <see langword="false"/>.
+                This method also returns <see langword="false"/> if <paramref name="item"/> was not found in 
+                the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveItemAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.SetItem(System.Int32,`0)">
+            <summary>
+            Replaces the element at the specified index.
+            </summary>
+            <param name="index">The zero-based index of the element to replace.</param>
+            <param name="item">The new value for the element at the specified index.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.OnReversed">
+            <summary>
+            The method that invokes the <see cref="E:MG.Collections.Classes.ListCollection`1.Reversed"/> event with -1 as the index and count.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.OnReversed(System.Int32,System.Int32)">
+            <summary>
+            The method that invoces the <see cref="E:MG.Collections.Classes.ListCollection`1.Reversed"/> event with the specified index and count of
+            the Reverse operation.
+            </summary>
+            <param name="index">The zero-based starting index of the range to reverse.</param>
+            <param name="count">The number of elements in the range to reverse.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.OnSorted(System.Collections.Generic.IComparer{`0},System.Int32,System.Int32)">
+            <summary>
+            The method that invokes the <see cref="E:MG.Collections.Classes.ListCollection`1.Sorted"/> event.
+            </summary>
+            <param name="index">The zero-based starting index of the range that was sorted.</param>
+            <param name="count">The length of the range that was sorted.</param>
+            <param name="comparerUsed">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation that was used when comparing elements, or <see langword="null"/> to use the default comparer
+                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ToPredicate(System.Func{`0,System.Boolean})">
+            <summary>
+            Converts the given <see cref="T:System.Func`2"/> into a <see cref="T:System.Predicate`1"/> delegate.
+            </summary>
+            <param name="func">The function to convert.</param>
+            <returns>
+                A <see cref="T:System.Predicate`1"/> delegate converted from <paramref name="func"/>.
+            </returns>
+        </member>
         <member name="T:MG.Collections.ManagedKeySortedList`2">
             <summary>
             A <see cref="T:System.Collections.Generic.SortedList`2"/> class where <typeparamref name="TKey"/> is automatically retrieved with 
@@ -376,6 +1212,33 @@
             <exception cref="T:System.InvalidOperationException">
                 <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an exception.
             </exception>
+            <exception cref="T:MG.Collections.Exceptions.KeyAlreadyExistsException">
+                The key resulting from <paramref name="value"/> was not unique.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.ManagedKeySortedList`2.AddItem``1(``0,`1,System.Func{``0,`0})">
+            <summary>
+            Attemps to add the specified value to the end of the list.  Instead of using the stored function to retrieve the key,
+            a separate function is specified from a new, generic input <typeparamref name="TInput"/>.
+            </summary>
+            <typeparam name="TInput">The generic type to retrieve <typeparamref name="TKey"/> from.</typeparam>
+            <param name="input">The input value to retrieve the <typeparamref name="TKey"/> key from.</param>
+            <param name="value">The value to store in the <see cref="T:MG.Collections.ManagedKeySortedList`2"/>.</param>
+            <param name="keySelector">The function to retrieve the key from a <typeparamref name="TInput"/> value.</param>
+            <returns>
+                <see langword="true"/> if <paramref name="value"/> was added to the list with the 
+                calculated <typeparamref name="TKey"/>; otherwise, <see langword="false"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                Either <paramref name="input"/> or <paramref name="keySelector"/> is <see langword="null"/>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an exception.
+            </exception>
+            <exception cref="T:MG.Collections.Exceptions.KeyAlreadyExistsException">
+                The resulting <typeparamref name="TKey"/> value from <paramref name="keySelector"/> and <paramref name="input"/>
+                is not unique.
+            </exception>
         </member>
         <member name="M:MG.Collections.ManagedKeySortedList`2.ClearItems">
             <summary>
@@ -395,7 +1258,7 @@
             </returns>
             <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
             <exception cref="T:System.InvalidOperationException">
-                The <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an <see cref="T:System.Exception"/> when fed
+                The <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an <see cref="T:System.Exception"/> when supplied
                 <paramref name="value"/>.
             </exception>
             <exception cref="T:System.Collections.Generic.KeyNotFoundException"><paramref name="key"/> was not found in the <see cref="T:MG.Collections.ManagedKeySortedList`2"/>.</exception>
@@ -1193,7 +2056,7 @@
                 <paramref name="collection"/> will be enumerated for uniqueness according to the provided 
                 <see cref="T:System.Collections.Generic.IEqualityComparer`1"/>.
                 
-                If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+                If <paramref name="collection"/> is null, no exception is thrown, and, instead, an empty
                 <see cref="T:MG.Collections.UniqueList`1"/> instance is initialized.
             </remarks>
             <param name="collection">
@@ -1203,6 +2066,29 @@
             <param name="equalityComparer">
                 The equality comparer that determines whether an element is unique.
             </param>
+        </member>
+        <member name="M:MG.Collections.UniqueList`1.Insert(System.Int32,`0)">
+            <summary>
+            Inserts an element into the <see cref="T:MG.Collections.UniqueList`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which item should be inserted.</param>
+            <param name="item">The object to insert. The value can be <see langword="null"/> for reference types.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.UniqueList`1.RemoveAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index of the <see cref="T:MG.Collections.UniqueList`1"/>.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
         </member>
         <member name="T:MG.Collections.UniqueListBase`1">
             <summary>
@@ -1738,7 +2624,7 @@
             </remarks>
             <param name="index">The negative or positive index value.</param>
             <returns>
-                The element of type <typeparamref name="TItem"/> at the specified proper index position; otherwise, 
+                The element of type <typeparamref name="T"/> at the specified proper index position; otherwise, 
                 if the index is determined to be out-of-range, then the default value of <typeparamref name="T"/>.
             </returns>
         </member>
@@ -1782,6 +2668,21 @@
                 -or
                 <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
             </exception>
+        </member>
+        <member name="P:MG.Collections.Events.SortedEventArgs`1.Comparer">
+            <summary>
+            The comparer used to sort the list.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Exceptions.FormattedException">
+            <summary>
+            An <see langword="abstract"/> exception class that provides a formatted base for message with arguments.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Exceptions.KeyAlreadyExistsException">
+            <summary>
+            An exception thrown when an attempt to add a key to a unique list or dictionary that already exists.
+            </summary>
         </member>
         <member name="T:MG.Collections.Exceptions.ReadOnlyException">
             <summary>
@@ -1939,8 +2840,8 @@
             Sorts the elements in the entire <see cref="T:MG.Collections.IReadOnlySortableList`1"/> using the specified comparer.
             </summary>
             <param name="comparer">
-                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or null to use the default comparer
-                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/> to 
+                use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
             </param>
         </member>
         <member name="M:MG.Collections.IReadOnlySortableList`1.Sort(System.Int32,System.Int32,System.Collections.Generic.IComparer{`0})">

--- a/MG.Collections.Tests/MG.Collections.Tests.csproj
+++ b/MG.Collections.Tests/MG.Collections.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <Version>1.0.2</Version>
+
+    <FileVersion>1.0.2</FileVersion>
+
+    <AssemblyVersion>1.0.2</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MG.Collections.Tests/ManagedKeyTest.cs
+++ b/MG.Collections.Tests/ManagedKeyTest.cs
@@ -9,6 +9,7 @@ using MG.Collections;
 using MG.Collections.Mocks;
 using Xunit;
 using Moq;
+using MG.Collections.Exceptions;
 
 namespace MG.Collections.Tests
 {
@@ -40,7 +41,7 @@ namespace MG.Collections.Tests
             Assert.True(col.Contains(mock));
             Assert.True(col.ContainsKey(24));
 
-            Assert.Throws<ArgumentException>(() => col.Add(mock));
+            Assert.Throws<KeyAlreadyExistsException>(() => col.Add(mock));
             Assert.Single(col);
 
             Assert.Throws<InvalidOperationException>(() => col.Add(null));

--- a/MG.Collections.Wpf-NET5/MG.Collections.Wpf-NET5.csproj
+++ b/MG.Collections.Wpf-NET5/MG.Collections.Wpf-NET5.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1-windows;net5.0-windows</TargetFrameworks>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <RootNamespace>MG.Collections.Wpf</RootNamespace>
     <UseWPF>true</UseWPF>
     <AssemblyName>MG.Collections.Wpf</AssemblyName>
     <Description>A library consisting of collections classes that can be used with .NET 5 WPF applications.</Description>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
-	<AssemblyTitle>MG.Collections.Wpf Core</AssemblyTitle>
-    <FileVersion>1.0.1</FileVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+	<AssemblyTitle>MG.Collections.Wpf .NET5</AssemblyTitle>
+    <FileVersion>1.0.2</FileVersion>
     <Copyright>Copyright © 2021 Yevrag35, LLC.  All rights reserved.</Copyright>
-    <Product>MG.Collections.Wpf Core</Product>
+    <Product>MG.Collections.Wpf .NET5</Product>
     <Company>Yevrag35, LLC.</Company>
     <Authors>Mike Garvey</Authors>
     <PackageProjectUrl>https://github.com/Yevrag35/ExpandedCollections</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Yevrag35/ExpandedCollections.git</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PackageIcon>Collections_Red.png</PackageIcon>
     <PackageIconUrl />
   </PropertyGroup>
@@ -25,16 +25,16 @@
 	  <Compile Include="..\MG.Collections.Wpf\**\*.cs" Exclude="..\MG.Collections.Wpf\Properties\**\*.cs;..\MG.Collections.Wpf\obj\**\*.*" />
   </ItemGroup>
 	
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows'">
+  <ItemGroup>
     <ProjectReference Include="..\MG.Collections-DotNet5\MG.Collections-NET5.csproj" />
   </ItemGroup>
 	
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1-windows'">
+  <!--<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1-windows'">
 	  <ProjectReference Include="..\MG.Collections\MG.Collections.csproj" />
-  </ItemGroup>
+  </ItemGroup>-->
 	
   <ItemGroup>
-    <None Include="E:\Local_Repos\MG.Collections\assets\Collections_Red.png">
+    <None Include="..\assets\Collections_Red.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
@@ -48,7 +48,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
-    <DocumentationFile>C:\Users\Mike\source\repos\MG.Collections\MG.Collections.Wpf-NET5\MG.Collections.Wpf.xml</DocumentationFile>
+    <DocumentationFile>MG.Collections.Wpf.xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/MG.Collections.Wpf-NETCore3.1/MG.Collections.Wpf-NETCore3.1.csproj
+++ b/MG.Collections.Wpf-NETCore3.1/MG.Collections.Wpf-NETCore3.1.csproj
@@ -1,0 +1,53 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1-windows</TargetFramework>
+    <RootNamespace>MG.Collections.Wpf</RootNamespace>
+	  <PackageId>MG.Collections</PackageId>
+	  <Authors>Mike Garvey</Authors>
+	  <Company>Yevrag35, LLC.</Company>
+	  <Copyright>Copyright © 2021 Yevrag35, LLC.  All rights reserved.</Copyright>
+    <UseWPF>true</UseWPF>
+	  <Product>MG.Collections .NETCore3.1</Product>
+    <Version>1.0.2</Version>
+    <FileVersion>1.0.2</FileVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+	  <AssemblyName>MG.Collections.Wpf</AssemblyName>
+	  <AssemblyTitle>
+		  MG.Collections.Wpf .NETCore3.1
+	  </AssemblyTitle>
+	  <PackageProjectUrl>https://github.com/Yevrag35/ExpandedCollections</PackageProjectUrl>
+	  <RepositoryUrl>https://github.com/Yevrag35/ExpandedCollections.git</RepositoryUrl>
+	  <RepositoryType>Git</RepositoryType>
+	  <Version>1.0.2</Version>
+	  <Description>A library consisting of collections classes that can be used with .NETCore 3.1 WPF applications.</Description>
+	<PackageIcon>Collections_Red.png</PackageIcon>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="..\MG.Collections.Wpf\**\*.cs" Exclude="..\MG.Collections.Wpf\Properties\**\*.cs;..\MG.Collections.Wpf\obj\**\*.*" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\MG.Collections\MG.Collections.csproj" />
+	</ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>full</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\assets\Collections_Red.png">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>none</DebugType>
+		<DebugSymbols>false</DebugSymbols>
+		<DocumentationFile>MG.Collections.Wpf.xml</DocumentationFile>
+	</PropertyGroup>
+
+</Project>

--- a/MG.Collections.Wpf-NETCore3.1/MG.Collections.Wpf.xml
+++ b/MG.Collections.Wpf-NETCore3.1/MG.Collections.Wpf.xml
@@ -1,0 +1,478 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>MG.Collections.Wpf</name>
+    </assembly>
+    <members>
+        <member name="T:MG.Collections.Wpf.ObservableViewedCollection`1">
+            <summary>
+            A dynamic data collection that is inherited from <see cref="T:System.Collections.ObjectModel.ObservableCollection`1"/> which provides
+            notifications when items get added, removed, or when the collection is refreshed.  Its members can also 
+            generate and store a <see cref="T:System.Windows.Data.ListCollectionView"/> that represents it.
+            </summary>
+            <typeparam name="T">The type of elements in the collection.</typeparam>
+        </member>
+        <member name="E:MG.Collections.Wpf.ObservableViewedCollection`1.ViewGenerated">
+            <summary>
+            Occurs when a new <see cref="T:System.Windows.Data.ListCollectionView"/> is generated for the <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/>.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Wpf.ObservableViewedCollection`1.ViewGenerating">
+            <summary>
+            Occurs when a new <see cref="T:System.Windows.Data.ListCollectionView"/> is currently being generated for <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/>.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.ObservableViewedCollection`1.IsViewGenerated">
+            <summary>
+            Indicates whether <see cref="P:MG.Collections.Wpf.ObservableViewedCollection`1.View"/> has been generated.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.ObservableViewedCollection`1.View">
+            <summary>
+            Represents the current <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/> as a collection view for grouping, sorting,
+            filtering, and navigating as a data collection.
+            </summary>
+            <remarks>
+                This is <see langword="null"/> until after calling <see cref="M:MG.Collections.Wpf.ObservableViewedCollection`1.GenerateView"/>.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.ObservableViewedCollection`1.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/> class that is empty.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.ObservableViewedCollection`1.#ctor(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/> class that contains elements
+            copied from the specified collection.
+            </summary>
+            <param name="collection">The collection from which the elements are copied.</param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Wpf.ObservableViewedCollection`1.#ctor(System.Collections.Generic.List{`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/> class that contains elements
+            copied from the specified <see cref="T:System.Collections.Generic.List`1"/>.
+            </summary>
+            <param name="list">The list from which the elements are copied.</param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Wpf.ObservableViewedCollection`1.GenerateView">
+            <summary>
+            Generates the <see cref="T:System.Windows.Data.ListCollectionView"/> and defines it as <see cref="P:MG.Collections.Wpf.ObservableViewedCollection`1.View"/> for the current 
+            <see cref="T:MG.Collections.Wpf.ObservableViewedCollection`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.ObservableViewedCollection`1.OnViewGenerated">
+            <summary>
+            An overridable method that is called after the <see cref="P:MG.Collections.Wpf.ObservableViewedCollection`1.View"/> is generated.
+            </summary>
+            <remarks>
+                By default, it simply calls the <see cref="E:MG.Collections.Wpf.ObservableViewedCollection`1.ViewGenerated"/> event.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.ObservableViewedCollection`1.OnViewGenerating">
+            <summary>
+            An overridable method that is called before the <see cref="P:MG.Collections.Wpf.ObservableViewedCollection`1.View"/> is generated.
+            </summary>
+            <remarks>
+                By default, it simply calls the <see cref="E:MG.Collections.Wpf.ObservableViewedCollection`1.ViewGenerating"/> event.
+            </remarks>
+        </member>
+        <member name="T:MG.Collections.Wpf.UniqueObservableList`1">
+            <summary>
+            A list class for WPF applications that provides the same functionality as would a combined 
+            <see cref="T:System.Collections.ObjectModel.ObservableCollection`1"/> and  <see cref="T:System.Collections.Generic.List`1"/> implementation, but also enforces every 
+            element to be unique according to a custom or the default <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> allowing it 
+            to provide access to the non-modifying <see cref="T:System.Collections.Generic.ISet`1"/> methods.
+            </summary>
+            <typeparam name="T">The element type in the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.</typeparam>
+        </member>
+        <member name="E:MG.Collections.Wpf.UniqueObservableList`1.CollectionChanged">
+            <summary>
+            Occurs when the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> changes.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Wpf.UniqueObservableList`1.PropertyChanged">
+            <summary>
+            Occurs when a property value changes.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Wpf.UniqueObservableList`1.ViewGenerated">
+            <summary>
+            Occurs when a new <see cref="T:System.Windows.Data.ListCollectionView"/> is generated for the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Wpf.UniqueObservableList`1.ViewGenerating">
+            <summary>
+            Occurs when a new <see cref="T:System.Windows.Data.ListCollectionView"/> is currently being generated for the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs)">
+            <summary>
+            Calls the <see cref="E:MG.Collections.Wpf.UniqueObservableList`1.CollectionChanged"/> event (if defined) passing the specified event arguments.
+            </summary>
+            <param name="e">The event arguments to pass to <see cref="E:MG.Collections.Wpf.UniqueObservableList`1.CollectionChanged"/>.</param>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.IsViewGenerated">
+            <summary>
+            Indicates whether <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> has been generated.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.StartingFilter">
+            <summary>
+            An optional starting filter for the <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> to use immediately after initialization.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.StartingLiveFilteringProperties">
+            <summary>
+            Optional starting property names for <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> that participate in filtering data in real time.
+            </summary>
+            <remarks>
+                Default is an empty <see cref="T:System.String"/> array.
+            </remarks>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.StartingLiveGroupingProperties">
+            <summary>
+            Optional starting property names for <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> that participate in grouping data in real time.
+            </summary>
+            <remarks>
+                Default is an empty <see cref="T:System.String"/> array.
+            </remarks>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.StartingLiveSortingProperties">
+            <summary>
+            Optional starting property names for <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> that participate in sorting data in real time.
+            </summary>
+            <remarks>
+                Default is an empty <see cref="T:System.String"/> array.
+            </remarks>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.View">
+            <summary>
+            Represents the current <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> as a collection view for grouping, sorting,
+            filtering, and navigating as a data collection.
+            </summary>
+            <remarks>
+                This is <see langword="null"/> until after calling <see cref="M:MG.Collections.Wpf.UniqueObservableList`1.GenerateView"/>.
+            </remarks>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.ViewIsFiltered">
+            <summary>
+            Indicates whether the current <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> is being filtered.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.UniqueObservableList`1.ViewNeedsRefresh">
+            <summary>
+            Indicates whether <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> needs to be refreshed.
+            </summary>
+            <returns>
+                <see langword="true"/> if the view needs to be refreshed; otherwise, <see langword="false"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> class that is empty
+            and has the default initial capacity and default equality comparer for <typeparamref name="T"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.#ctor(System.Int32)">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> class that is empty
+            and has the specified initial capacity and default equality comparer for <typeparamref name="T"/>.
+            </summary>
+            <param name="capacity">The number of elements that the new collection can initially store.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0.</exception>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.#ctor(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Initializes a new <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> instance that contains elements copied from the specified
+            collection and has sufficient capacity to accomodate the number of unique elements copied.
+            </summary>
+            <remarks>
+                <paramref name="items"/> will be enumerated for uniqueness according to the default
+                <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> for type <typeparamref name="T"/>.
+                
+                If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+                <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> instance is initialized.
+            </remarks>
+            <param name="items">
+                The collection whose elements will be enumerated for uniqueness and added
+                to the list.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.#ctor(System.Collections.Generic.IEqualityComparer{`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> class that is empty
+            and has the default initial capacity and the specified equality comparer for <typeparamref name="T"/>.
+            </summary>
+            <param name="equalityComparer">
+                The <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> implementation to use when comparing values in the list, or
+                <see langword="null"/> to use the default <see cref="T:System.Collections.Generic.EqualityComparer`1"/> implementation for the
+                type <typeparamref name="T"/>.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.#ctor(System.Int32,System.Collections.Generic.IEqualityComparer{`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> class that is empty, has the specified
+            initial capacity, and uses the specified equality comparer for the <typeparamref name="T"/> type.
+            </summary>
+            <param name="capacity">The number of elements that the new collection can initially store.</param>
+            <param name="equalityComparer">
+                The <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> implementation to use when comparing values in the list, or
+                <see langword="null"/> to use the default <see cref="T:System.Collections.Generic.EqualityComparer`1"/> implementation for the
+                type <typeparamref name="T"/>.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0.</exception>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.#ctor(System.Collections.Generic.IEnumerable{`0},System.Collections.Generic.IEqualityComparer{`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> class that uses the specified comparer for 
+            the <typeparamref name="T"/> type, contains elements copied from the specified collection, and sufficient capacity
+            to accommodate the number of elements copied.
+            </summary>
+            <remarks>
+                If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+                <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> instance is initialized.
+            </remarks>
+            <param name="items">The collection whose elements are copied to the new list.</param>
+            <param name="equalityComparer">
+                The <see cref="T:System.Collections.Generic.IEqualityComparer`1"/> implementation to use when comparing values in the list, or
+                <see langword="null"/> to use the default <see cref="T:System.Collections.Generic.EqualityComparer`1"/> implementation for the
+                type <typeparamref name="T"/>.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.AddItem(`0)">
+            <summary>
+            Adds an object to the end of the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </summary>
+            <param name="item">The object to add.</param>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.ClearItems">
+            <summary>
+            Removes all elements from the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.InsertItem(System.Int32,`0)">
+            <summary>
+            Inserts an elements into the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which <paramref name="item"/> should be inserted.</param>
+            <param name="item">The object to insert.</param>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.RemoveItem(`0)">
+            <summary>
+            Removes the specified element from the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </summary>
+            <param name="item">The element to remove.</param>
+            <returns>
+                <see langword="true"/> if <paramref name="item"/> is successfully removed; otherwise <see langword="false"/>.
+                This method also returns <see langword="false"/> if <paramref name="item"/> was not found in 
+                the <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.RemoveItemAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is equal to or greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.SetItem(System.Int32,`0)">
+            <summary>
+            Replaces the item at the specified index.
+            </summary>
+            <param name="index">The zero-based index of the element to replace.</param>
+            <param name="item"></param>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.GenerateView">
+            <summary>
+            Generates the <see cref="T:System.Windows.Data.ListCollectionView"/> and defines it as <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> for the current <see cref="T:MG.Collections.Wpf.UniqueObservableList`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.OnViewGenerated">
+            <summary>
+            A definable method that is called after the <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> is generated.
+            </summary>
+            <remarks>
+                By default, it simply calls the <see cref="E:MG.Collections.Wpf.UniqueObservableList`1.ViewGenerated"/> event.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.OnViewGenerating">
+            <summary>
+            A definable method that is called before the <see cref="P:MG.Collections.Wpf.UniqueObservableList`1.View"/> is generated.
+            </summary>
+            <remarks>
+                By default, it simply calls the <see cref="E:MG.Collections.Wpf.UniqueObservableList`1.ViewGenerating"/> event.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.NegatePredicate(System.Predicate{`0})">
+            <summary>
+            Takes a given <see cref="T:System.Predicate`1"/> and simply negates the <see cref="T:System.Boolean"/> result.
+            </summary>
+            <param name="predicate">The predicate to negate.</param>
+            <returns>
+                A <see cref="T:System.Boolean"/> value that is opposite to the resolved value of <paramref name="predicate"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Wpf.UniqueObservableList`1.NotifyChange(System.String)">
+            <summary>
+            Calls the <see cref="E:MG.Collections.Wpf.UniqueObservableList`1.PropertyChanged"/> event if defined for the specified property name.
+            </summary>
+            <remarks>
+                Simply a convenience method that is equivalent to 
+                this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            </remarks>
+            <param name="propertyName">The name of the property to notify on.</param>
+        </member>
+        <member name="T:MG.Collections.Wpf.ViewGeneratedEventHandler">
+            <summary>
+            Represents a method that handles the ? event.
+            </summary>
+            <param name="sender">The object that raised the event.</param>
+            <param name="e">Information about the <see cref="T:System.ComponentModel.ICollectionView"/> that was generated.</param>
+        </member>
+        <member name="T:MG.Collections.Wpf.ViewGeneratedEventArgs">
+            <summary>
+            An <see cref="T:System.EventArgs"/> class containing information that an <see cref="T:MG.Collections.Wpf.IViewableList"/> generated
+            an <see cref="T:System.ComponentModel.ICollectionView"/>.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.ViewGeneratedEventArgs.ViewType">
+            <summary>
+            Indicates the type of view that was generated.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Wpf.ViewGeneratedEventArgs.#ctor(MG.Collections.Wpf.GeneratedViewType)">
+            <summary>
+            Initializes a new instance of the <see cref="T:MG.Collections.Wpf.ViewGeneratedEventArgs"/> class with the optional information
+            about what kind of view was generated.
+            </summary>
+            <param name="viewType">The type of view that was generated.  The default is <see cref="F:MG.Collections.Wpf.GeneratedViewType.Unknown"/>.</param>
+        </member>
+        <member name="T:MG.Collections.Wpf.GeneratedViewType">
+            <summary>
+            Describes the type of <see cref="T:System.ComponentModel.ICollectionView"/> generated.
+            </summary>
+        </member>
+        <member name="F:MG.Collections.Wpf.GeneratedViewType.Unknown">
+            <summary>
+            No information about the <see cref="T:System.ComponentModel.ICollectionView"/> was provided.
+            </summary>
+        </member>
+        <member name="F:MG.Collections.Wpf.GeneratedViewType.List">
+            <summary>
+            The view is of the <see cref="T:System.Windows.Data.ListCollectionView"/> type.
+            </summary>
+        </member>
+        <member name="F:MG.Collections.Wpf.GeneratedViewType.BindingList">
+            <summary>
+            The view is of the <see cref="T:System.Windows.Data.BindingListCollectionView"/> type.
+            </summary>
+        </member>
+        <member name="F:MG.Collections.Wpf.GeneratedViewType.ItemCollection">
+            <summary>
+            The view is of the <see cref="T:System.Windows.Controls.ItemCollection"/> type.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Wpf.INotifyViewGenerated">
+            <summary>
+            Notifies listeners when a new <see cref="T:System.ComponentModel.ICollectionView"/> is generated.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Wpf.INotifyViewGenerated.ViewGenerated">
+            <summary>
+            Occurs when a new <see cref="T:System.ComponentModel.ICollectionView"/> is generated.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Wpf.INotifyViewGenerating">
+            <summary>
+            Notifies listeners when a new <see cref="T:System.ComponentModel.ICollectionView"/> is in the process of being generated.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Wpf.INotifyViewGenerating.ViewGenerating">
+            <summary>
+            Occurs when a new <see cref="T:System.ComponentModel.ICollectionView"/> is currently being generated.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Wpf.Interfaces.IViewableBindingList">
+            <summary>
+            An interface representing a non-generic list for WPF applications that hosts its own 
+            <see cref="T:System.Windows.Data.BindingListCollectionView"/> of itself.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.Interfaces.IViewableBindingList.IsViewGenerated">
+            <summary>
+            Indicates whether <see cref="P:MG.Collections.Wpf.Interfaces.IViewableBindingList.View"/> has been generated.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.Interfaces.IViewableBindingList.View">
+            <summary>
+            Represents the current <see cref="T:MG.Collections.Wpf.Interfaces.IViewableBindingList"/> as a list view for grouping, sorting,
+            filtering, and navigating as a data collection.
+            </summary>
+            <remarks>
+                This is <see langword="null"/> until after calling <see cref="M:MG.Collections.Wpf.Interfaces.IViewableBindingList.GenerateView"/>.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.Interfaces.IViewableBindingList.GenerateView">
+            <summary>
+            Generates the <see cref="T:System.Windows.Data.BindingListCollectionView"/> and defines it as <see cref="P:MG.Collections.Wpf.Interfaces.IViewableBindingList.View"/>.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Wpf.IViewableCollection">
+            <summary>
+            An interface representing a generic collection for WPF applications that hosts its own 
+            <see cref="T:System.ComponentModel.ICollectionView"/> of itself.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.IViewableCollection.IsViewGenerated">
+            <summary>
+            Indicates whether <see cref="P:MG.Collections.Wpf.IViewableCollection.View"/> has been generated.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.IViewableCollection.View">
+            <summary>
+            Represents the current <see cref="T:MG.Collections.Wpf.IViewableCollection"/> as view for grouping, sorting,
+            filtering, and navigating as a data collection.
+            </summary>
+            <remarks>
+                This is <see langword="null"/> until after calling <see cref="M:MG.Collections.Wpf.IViewableCollection.GenerateView"/>.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.IViewableCollection.GenerateView">
+            <summary>
+            Generates the <see cref="T:System.ComponentModel.ICollectionView"/> and defines it as <see cref="P:MG.Collections.Wpf.IViewableCollection.View"/>.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Wpf.IViewableList">
+            <summary>
+            An interface representing a generic list for WPF applications that hosts its own 
+            <see cref="T:System.Windows.Data.ListCollectionView"/> of itself.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.IViewableList.IsViewGenerated">
+            <summary>
+            Indicates whether <see cref="P:MG.Collections.Wpf.IViewableList.View"/> has been generated.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Wpf.IViewableList.View">
+            <summary>
+            Represents the current <see cref="T:MG.Collections.Wpf.IViewableList"/> as a list view for grouping, sorting,
+            filtering, and navigating as a data collection.
+            </summary>
+            <remarks>
+                This is <see langword="null"/> until after calling <see cref="M:MG.Collections.Wpf.IViewableList.GenerateView"/>.
+            </remarks>
+        </member>
+        <member name="M:MG.Collections.Wpf.IViewableList.GenerateView">
+            <summary>
+            Generates the <see cref="T:System.Windows.Data.ListCollectionView"/> and defines it as <see cref="P:MG.Collections.Wpf.IViewableList.View"/>.
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/MG.Collections.Wpf.nuspec
+++ b/MG.Collections.Wpf.nuspec
@@ -3,7 +3,7 @@
 	<metadata>
 		<id>MG.Collections.Wpf</id>
 		<title>MG.Collections.Wpf</title>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 		<authors>Mike Garvey</authors>
 		<owners>Yevrag35, LLC.</owners>
 		<icon>images\Collections_Red.png</icon>
@@ -14,25 +14,25 @@
 		<description>A library consisting of list, collection, and set classes that can be used with WPF applications.</description>
 		<copyright>Copyright © 2021 Yevrag35, LLC.  All rights reserved.</copyright>
 		<repository type="Git" url="https://github.com/Yevrag35/ExpandedCollections.git" />
-		<summary>A library consisting of list, collection, and set classes that can be used with WPF applications.</summary>
+		<summary>Adding ListCollection class for combined List and Collection behavior for derived classes.</summary>
 		<releaseNotes>Initial Release</releaseNotes>
 		<dependencies>
 			<group targetFramework=".NETFramework4.6.2">
-				<dependency id="MG.Collections" version="1.0.1"/>
+				<dependency id="MG.Collections" version="1.0.2"/>
 			</group>
 			<group targetFramework=".NETCoreApp3.1">
-				<dependency id="MG.Collections" version="1.0.1"/>
+				<dependency id="MG.Collections" version="1.0.2"/>
 			</group>
 			<group targetFramework=".NET5">
-				<dependency id="MG.Collections" version="1.0.1"/>
+				<dependency id="MG.Collections" version="1.0.2"/>
 			</group>
 		</dependencies>
 	</metadata>
 	<files>
 		<file src="LICENSE.txt" target="licenses\" />
 		<file src="assets\Collections_Red.png" target="images\"/>
-		<file src="MG.Collections.Wpf-NET5\bin\Release\netcoreapp3.1-windows\MG.Collections.Wpf.dll" target="lib\netcoreapp3.1\MG.Collections.Wpf.dll" />
-		<file src="MG.Collections.Wpf-NET5\bin\Release\netcoreapp3.1-windows\MG.Collections.Wpf.xml" target="lib\netcoreapp3.1\MG.Collections.Wpf.xml" />
+		<file src="MG.Collections.Wpf-NETCore3.1\bin\Release\netcoreapp3.1-windows\MG.Collections.Wpf.dll" target="lib\netcoreapp3.1\MG.Collections.Wpf.dll" />
+		<file src="MG.Collections.Wpf-NETCore3.1\bin\Release\netcoreapp3.1-windows\MG.Collections.Wpf.xml" target="lib\netcoreapp3.1\MG.Collections.Wpf.xml" />
 		<file src="MG.Collections.Wpf\bin\Release\MG.Collections.Wpf.xml" target="lib\net462\MG.Collections.Wpf.xml" />
 		<file src="MG.Collections.Wpf\bin\Release\MG.Collections.Wpf.dll" target="lib\net462\MG.Collections.Wpf.dll" />
 		<file src="MG.Collections.Wpf-NET5\bin\Release\net5.0-windows\MG.Collections.Wpf.xml" target="lib\net5.0\MG.Collections.Wpf.xml" />

--- a/MG.Collections.Wpf/MG.Collections.Wpf.csproj
+++ b/MG.Collections.Wpf/MG.Collections.Wpf.csproj
@@ -59,5 +59,10 @@
       <Name>MG.Collections</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.editorconfig">
+      <Link>.editorconfig</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MG.Collections.Wpf/Properties/AssemblyInfo.cs
+++ b/MG.Collections.Wpf/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1")]
-[assembly: AssemblyFileVersion("1.0.1")]
+[assembly: AssemblyVersion("1.0.2")]
+[assembly: AssemblyFileVersion("1.0.2")]

--- a/MG.Collections.nuspec
+++ b/MG.Collections.nuspec
@@ -3,7 +3,7 @@
 	<metadata>
 		<id>MG.Collections</id>
 		<title>MG.Collections</title>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 		<authors>Mike Garvey</authors>
 		<owners>Yevrag35, LLC.</owners>
 		<icon>images\Collections_Red.png</icon>
@@ -15,7 +15,7 @@
 		<copyright>Copyright © 2021 Yevrag35, LLC.  All rights reserved.</copyright>
 		<repository type="Git" url="https://github.com/Yevrag35/ExpandedCollections.git" />
 		<summary>A library consisting of specialized collection classes.</summary>
-		<releaseNotes>Initial Release</releaseNotes>
+		<releaseNotes>Adding ListCollection class for combined List and Collection behavior for derived classes.</releaseNotes>
 		<dependencies>
 			<group targetFramework=".NETFramework4.6.2"/>
 			<group targetFramework=".NETStandard2.0"/>

--- a/MG.Collections.sln
+++ b/MG.Collections.sln
@@ -11,7 +11,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MG.Collections-NET5", "MG.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MG.Collections.Wpf", "MG.Collections.Wpf\MG.Collections.Wpf.csproj", "{84725A76-3B45-4DAE-8D35-8009113517F1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MG.Collections.Wpf-NET5", "MG.Collections.Wpf-NET5\MG.Collections.Wpf-NET5.csproj", "{C906A96B-7A61-4BA3-8EE3-7A8F0A6178D4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MG.Collections.Wpf-NET5", "MG.Collections.Wpf-NET5\MG.Collections.Wpf-NET5.csproj", "{C906A96B-7A61-4BA3-8EE3-7A8F0A6178D4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EB079B1D-F969-4A77-989B-FD551250F5DF}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MG.Collections.Wpf-NETCore3.1", "MG.Collections.Wpf-NETCore3.1\MG.Collections.Wpf-NETCore3.1.csproj", "{72B061CF-DFAD-4697-8897-B129BA72BEC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +46,10 @@ Global
 		{C906A96B-7A61-4BA3-8EE3-7A8F0A6178D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C906A96B-7A61-4BA3-8EE3-7A8F0A6178D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C906A96B-7A61-4BA3-8EE3-7A8F0A6178D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72B061CF-DFAD-4697-8897-B129BA72BEC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72B061CF-DFAD-4697-8897-B129BA72BEC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72B061CF-DFAD-4697-8897-B129BA72BEC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72B061CF-DFAD-4697-8897-B129BA72BEC6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MG.Collections/Classes/ListCollection.cs
+++ b/MG.Collections/Classes/ListCollection.cs
@@ -1,0 +1,1150 @@
+﻿using MG.Collections.Events;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MG.Collections.Classes
+{
+    /// <summary>
+    /// An indentical implementation to <see cref="List{T}"/> but with the ability for derived classes to override
+    /// the Add, Insert, Set, and Remove methods.  Similar to the way <see cref="System.Collections.ObjectModel.Collection{T}"/>
+    /// allows.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the <see cref="ListCollection{T}"/>.</typeparam>
+    public class ListCollection<T> : IList<T>, IReadOnlyList<T>, ISearchableList<T>, IList, ICollection, IReadOnlySortableList<T>
+    {
+        #region PRIVATE FIELDS/CONSTANTS
+        private const int DEFAULT_CAPACITY = 0;
+        private readonly List<T> InnerList;
+
+        #endregion
+
+        #region EVENTS
+        /// <summary>
+        /// An event that occurs when the <see cref="ListCollection{T}"/> is reversed through the 'Reverse' methods.
+        /// </summary>
+        public event ReversedEventHandler Reversed;
+        /// <summary>
+        /// An event that occurs when the <see cref="ListCollection{T}"/> is sorted through the 'Sort' methods.
+        /// </summary>
+        public event SortedEventHandler<T> Sorted;
+
+        #endregion
+
+        #region INDEXERS
+        /// <summary>
+        /// Gets or sets the element at the specified index.
+        /// </summary>
+        /// <param name="index">The index value for zero-based indexing.</param>
+        /// <returns>
+        ///     The element at the specified index.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0
+        ///     -or-
+        ///     <paramref name="index"/> is greater than or equal than <see cref="Count"/>.
+        /// </exception>
+        public T this[int index]
+        {
+            get => InnerList[index];
+            set => this.SetItem(index, value);
+        }
+
+        #endregion
+
+        #region PROPERTIES
+        /// <summary>
+        /// Gets or sets the total number of elements the internal data structure can hold without resizing.
+        /// </summary>
+        /// <returns>
+        ///     The number of elements that the <see cref="ListCollection{T}"/> can contain before resizing is required.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <see cref="Capacity"/> is set to a value that is less than <see cref="Count"/>.
+        /// </exception>
+        /// <exception cref="OutOfMemoryException">
+        ///     There is not enough memory available on the system.
+        /// </exception>
+        public int Capacity
+        {
+            get => this.InnerList.Capacity;
+            set => this.InnerList.Capacity = value;
+        }
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        /// <returns>
+        ///     The number of elements contained in the <see cref="ListCollection{T}"/>.
+        /// </returns>
+        public int Count => this.InnerList.Count;
+        public bool IsReadOnly { get; protected set; }
+
+        #endregion
+
+        #region CONSTRUCTORS
+        /// <summary>
+        /// The default constructor.  Initializes an empty <see cref="ListCollection{T}"/> with the default capacity.
+        /// </summary>
+        public ListCollection()
+            : this(DEFAULT_CAPACITY)
+        {
+        }
+        /// <summary>
+        /// Initializes an empty <see cref="ListCollection{T}"/> with the specified capacity.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the new collection can initially store.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0.</exception>
+        public ListCollection(int capacity)
+        {
+            this.InnerList = new List<T>(capacity);
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="ListCollection{T}"/> instance that contains elements copied from the specified
+        /// collection and has sufficient capacity to accomodate the number of elements copied.
+        /// </summary>
+        /// <remarks>
+        ///     If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+        ///     <see cref="ListCollection{T}"/> instance is initialized.
+        /// </remarks>
+        /// <param name="items">
+        ///     The collection whose elements will be copied to the <see cref="ListCollection{T}"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+        public ListCollection(IEnumerable<T> items)
+            : this(items, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="ListCollection{T}"/> instance that contains elements copied from the specified
+        /// collection and has sufficient capacity to accomodate the number of elements copied.  It also provides an option to
+        /// initialize the collection even if <paramref name="items"/> is <see langword="null"/>.
+        /// </summary>
+        /// <remarks>
+        ///     If <paramref name="items"/> is null and <paramref name="initializeIfNull"/> is 
+        ///     <see langword="false"/>, an <see cref="ArgumentNullException"/> exception is thrown.  If, however,
+        ///     <paramref name="initializeIfNull"/> is <see langword="true"/>, an empty
+        ///     <see cref="ListCollection{T}"/> instance is initialized with the default capacity instead.
+        /// </remarks>
+        /// <param name="items">
+        ///     The collection whose elements will be copied to the <see cref="ListCollection{T}"/>.
+        /// </param>
+        /// <param name="initializeIfNull">
+        ///     Indicates that the <see cref="ListCollection{T}"/> should be initialized even if <paramref name="items"/>
+        ///     is found to be <see langword="null"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="initializeIfNull"/> is <see langword="false"/> and
+        ///     <paramref name="items"/> is <see langword="null"/>.
+        /// </exception>
+        public ListCollection(IEnumerable<T> items, bool initializeIfNull)
+        {
+            this.InnerList = initializeIfNull && items is null
+                ? new List<T>(DEFAULT_CAPACITY)
+                : new List<T>(items);
+        }
+
+        #endregion
+
+        #region BASE METHODS
+        /// <summary>
+        /// Adds an item to the end of the collection.
+        /// </summary>
+        /// <param name="item">The object to be added to the end of the collection.</param>
+        public void Add(T item)
+        {
+            this.AddItem(item);
+        }
+        /// <summary>
+        /// Removes all elements from the <see cref="UniqueListBase{T}"/>.
+        /// </summary>
+        public void Clear()
+        {
+            this.ClearItems();
+        }
+        /// <summary>
+        /// Determines whether an element is in the <see cref="UniqueListBase{T}"/>.
+        /// </summary>
+        /// <param name="item">
+        /// The object to locate in the <see cref="UniqueListBase{T}"/>.  The value can be null for reference types.
+        /// </param>
+        public bool Contains(T item)
+        {
+            return this.InnerList.Contains(item);
+        }
+        /// <summary>
+        /// Copies the entire <see cref="UniqueListBase{T}"/> to a compatible one-dimensional array, starting at
+        /// the specified index of the target array.
+        /// </summary>
+        /// <param name="array">
+        /// The one-dimensional array that is the destination of the elements copied from
+        /// <see cref="UniqueListBase{T}"/>.  The array must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">The zero-based index in the target array at which copying begins.</param>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="ArgumentOutOfRangeException"/>
+        /// <exception cref="ArgumentException"/>
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            this.InnerList.CopyTo(array, arrayIndex);
+        }
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the first occurrence
+        /// within the entire <see cref="UniqueListBase{T}"/>.
+        /// </summary>
+        /// <param name="item">The object to locate in the <see cref="UniqueListBase{T}"/>.  The value can be null for reference types.</param>
+        public int IndexOf(T item)
+        {
+            return this.InnerList.IndexOf(item);
+        }
+        /// <summary>
+        /// Removes the specific object from the <see cref="UniqueListBase{T}"/>.
+        /// </summary>
+        /// <param name="item">
+        ///     The object to remove from the <see cref="UniqueListBase{T}"/>.
+        /// </param>
+        public bool Remove(T item)
+        {
+            return this.RemoveItem(item);
+        }
+        /// <summary>
+        /// Copies the elements of the <see cref="UniqueList{T}"/> to a new array.
+        /// </summary>
+        /// <returns>
+        ///     An array containing copies of the elements of the <see cref="UniqueList{T}"/>.  If the list contains no elements, 
+        ///     an empty array is returned.
+        /// </returns>
+        public T[] ToArray()
+        {
+            return this.InnerList.ToArray();
+        }
+
+        /// <summary>
+        /// Determines whether every element in the <see cref="ReadOnlyList{T}"/> matches the conditions
+        /// defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate that defines the conditions to check against the elements.</param>
+        /// <returns>
+        ///     <see langword="true"/>: if every element in the list matches the conditions defined; 
+        ///     otherwise, <see langword="false"/>.
+        ///     If the list has no elements, the return value is <see langword="true"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public bool TrueForAll(Func<T, bool> match)
+        {
+            return this.InnerList.TrueForAll(ToPredicate(match));
+        }
+
+        #endregion
+
+        #region LIST SPECIAL METHODS
+        /// <summary>
+        /// Searches the entire sorted <see cref="ListCollection{T}"/> for an element using the default comparer
+        /// and returns the zero-based index of the element.
+        /// </summary>
+        /// <param name="item">The object to locate.  The value can be <see langword="null"/> for reference types.</param>
+        /// <returns>
+        ///     The zero-based index of <paramref name="item"/> in the sorted <see cref="ListCollection{T}"/>,
+        ///     if <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement
+        ///     of the index of the next element that is larger than <paramref name="item"/> or, if there is no
+        ///     larger element, the bitwise complement of <see cref="Count"/>.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///     The default comparer <see cref="Comparer{T}.Default"/> cannot find
+        ///     an implementation of the <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/>
+        ///     interface for type <typeparamref name="T"/>.
+        /// </exception>
+        public int BinarySearch(T item)
+        {
+            return this.BinarySearch(item);
+        }
+        /// <summary>
+        /// Searches the entire sorted <see cref="ListCollection{T}"/> for an element using the specified comparer and
+        /// returns the zero-based index of the elements.
+        /// </summary>
+        /// <param name="item">The object to locate.  The value can be <see langword="null"/> for reference types.</param>
+        /// <param name="comparer">
+        ///     The <see cref="IComparer{T}"/> implementation to use when comparing elements.
+        ///     -or-
+        ///     <see langword="null"/> to use the default comparer <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <returns>
+        ///     The zero-based index of <paramref name="item"/> in the sorted <see cref="ListCollection{T}"/>, if
+        ///     <paramref name="item"/> is found; otherwise, a negative number that is bitwise complement of the index
+        ///     of the next element that is larger than <paramref name="item"/> or, if there is no larger element, the
+        ///     bitwise complement of <see cref="Count"/>.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///     <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="Comparer{T}.Default"/> 
+        ///     cannot find an implementation of the <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/>
+        ///     interface for type <typeparamref name="T"/>.
+        /// </exception>
+        public int BinarySearch(T item, IComparer<T> comparer)
+        {
+            return this.BinarySearch(item, comparer);
+        }
+        /// <summary>
+        ///     Searches a range of elements in the sorted <see cref="ListCollection{T}"/>
+        ///     for an element using the specified comparer and returns the zero-based index
+        ///     of the element.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range to search.</param>
+        /// <param name="count">The length of the range to search.</param>
+        /// <param name="item">The object to locate. The value can be <see langword="null"/> for reference types.</param>
+        /// <param name="comparer">
+        ///     The <see cref="IComparer{T}"/> implementation to use when comparing elements.
+        ///     -or-
+        ///     <see langword="null"/> to use the default comparer <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <returns>
+        ///     The zero-based index of <paramref name="item"/> in the sorted <see cref="ListCollection{T}"/>, if
+        ///     <paramref name="item"/> is found; otherwise, a negative number that is bitwise complement of the index
+        ///     of the next element that is larger than <paramref name="item"/> or, if there is no larger element, the
+        ///     bitwise complement of <see cref="Count"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> and <paramref name="count"/> do not denote a valid range in the
+        ///     <see cref="ListCollection{T}"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="Comparer{T}.Default"/> 
+        ///     cannot find an implementation of the <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/>
+        ///     interface for type <typeparamref name="T"/>.
+        /// </exception>
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer)
+        {
+            return this.BinarySearch(index, count, item, comparer);
+        }
+        /// <summary>
+        /// Converts the elements in the current <see cref="ListCollection{T}"/> to another
+        ///     type, and returns a list containing the converted elements.
+        /// </summary>
+        /// <typeparam name="TOutput">
+        ///     The type of the elements of the target array.
+        /// </typeparam>
+        /// <param name="converter">
+        ///     A <see cref="Converter{TInput, TOutput}"/> delegate that converts each element from one type
+        ///     to another type.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="List{T}"/> of the target type containing the converted elements from the
+        ///     current <see cref="ListCollection{T}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="converter"/> is <see langword="null"/>.</exception>
+        public List<TOutput> ConvertAll<TOutput>(Converter<T, TOutput> converter)
+        {
+            return this.InnerList.ConvertAll(converter);
+        }
+        /// <summary>
+        /// Copies the entire <see cref="ListCollection{T}"/> to a compatible one-dimensional array, starting at the
+        /// beginning of the target array.
+        /// </summary>
+        /// <param name="array">
+        ///     The one-dimensional <see cref="Array"/> that is the destination of the elements copied from
+        ///     <see cref="ListCollection{T}"/>.  The <see cref="Array"/> must have zero-based indexing.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     The number of elements in the source <see cref="ListCollection{T}"/> is greater than the number of
+        ///     elements that the destination array can contain.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        public void CopyTo(T[] array)
+        {
+            this.CopyTo(array);
+        }
+        /// <summary>
+        /// Copies a range of elements from the <see cref="ListCollection{T}"/> to a compatible one-dimensional array,
+        /// starting at the specified index of the target array.
+        /// </summary>
+        /// <param name="index">
+        ///     The zero-based index in the source <see cref="ListCollection{T}"/> at which copying begins.
+        /// </param>
+        /// <param name="array">
+        ///     The one-dimensional <see cref="Array"/> that is the destination of the elements copied from
+        ///     <see cref="ListCollection{T}"/>.  The <see cref="Array"/> must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">
+        ///     The zero-based index in <paramref name="array"/> at which copying begins.
+        /// </param>
+        /// <param name="count">The number of elements to copy.</param>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="index"/> is equal to or greater than <see cref="Count"/> of the source <see cref="ListCollection{T}"/>.
+        ///     -or-
+        ///     The number of elements from <paramref name="index"/> to the end of the source <see cref="ListCollection{T}"/> is greater
+        ///     than the available space from <paramref name="arrayIndex"/> to the end of the destination array.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        /// </exception>
+        public void CopyTo(int index, T[] array, int arrayIndex, int count)
+        {
+            this.InnerList.CopyTo(index, array, arrayIndex, count);
+        }
+        /// <summary>
+        /// Performs the specified action on each element of the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        /// <param name="action">
+        ///     The <see cref="Action{T}"/> delegate to perform on each element of the <see cref="ListCollection{T}"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     An element in the collection has been modified.
+        /// </exception>
+        public void ForEach(Action<T> action)
+        {
+            this.InnerList.ForEach(action);
+        }
+        /// <summary>
+        /// Inserts the elements of a collection into the <see cref="ListCollection{T}"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted.</param>
+        /// <param name="collection">
+        ///     The collection whose elements should be insert into the <see cref="ListCollection{T}"/>.  The collection
+        ///     itself cannot be <see langword="null"/>, but it can contain elements that are <see langword="null"/>, if 
+        ///     type <typeparamref name="T"/> is a reference type.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> is greater than <see cref="Count"/>.
+        /// </exception>
+        public void InsertRange(int index, IEnumerable<T> collection)
+        {
+            this.InnerList.InsertRange(index, collection);
+        }
+        /// <summary>
+        /// Removes all the elements that match the conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">
+        ///     The <see cref="Func{T, TResult}"/> delegate that defines the conditions of the elements to remove.
+        /// </param>
+        /// <returns>
+        ///     The number of elements removed from the <see cref="ListCollection{T}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="match"/> is <see langword="null"/>.
+        /// </exception>
+        public int RemoveAll(Func<T, bool> match)
+        {
+            return this.InnerList.RemoveAll(ToPredicate(match));
+        }
+        /// <summary>
+        /// Removes a range of elements from the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range of elements to remove.</param>
+        /// <param name="count">The number of elements to remove.</param>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements
+        ///     in the <see cref="ListCollection{T}"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        /// </exception>
+        public void RemoveRange(int index, int count)
+        {
+            this.InnerList.RemoveRange(index, count);
+        }
+        /// <summary>
+        /// Sets the capacity to the actual number of elements in the <see cref="ListCollection{T}"/>,
+        /// if that number is less than a threshold value.
+        /// </summary>
+        public void TrimExcess()
+        {
+            this.InnerList.TrimExcess();
+        }
+
+        #endregion
+
+        #region READONLY LIST METHODS
+        /// <summary>
+        ///     Determines whether the <see cref="ReadOnlyList{T}"/> contains elements that
+        ///     match the conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">
+        ///     The <see cref="Func{T, TResult}"/> delegate that defines the conditions of the 
+        ///     elements to search for.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/>:
+        ///     if the <see cref="ReadOnlyList{T}"/> contains one or more elements that
+        ///     <paramref name="match"/> defined.
+        /// <see langword="false"/>:
+        ///     otherwise.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public bool Exists(Func<T, bool> match)
+        {
+            return this.InnerList.Exists(ToPredicate(match));
+        }
+
+        /// <summary>
+        ///     Searches for an element that matches the conditions defined by the specified
+        ///     predicate, and returns the first occurrence within the entire <see cref="ReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="match">
+        ///     The <see cref="Func{T, TResult}"/> delegate that defines the conditions of the
+        ///     elements to search for.
+        /// </param>
+        /// <returns>
+        ///     The first element that matches the conditions if found; otherwise the default value for <typeparamref name="T"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public T Find(Func<T, bool> match)
+        {
+            return this.InnerList.Find(ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Retrieves all of the elements that match the conditions defined by the specified predicate.
+        /// </summary>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     An <see cref="List{T}"/> containing all of the elements that match the conditions if found; 
+        ///     otherwise, an empty list.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public List<T> FindAll(Func<T, bool> match)
+        {
+            return this.InnerList.FindAll(ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+        /// index of the first occurrence within the entire <see cref="ReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The zero-based index of the first occurrence of an element that matches the conditions defined
+        ///     by <paramref name="match"/> if found; otherwise, -1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public int FindIndex(Func<T, bool> match)
+        {
+            return this.InnerList.FindIndex(ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+        /// index of the first occurrence within the range of elements in the <see cref="ReadOnlyList{T}"/> that extends from the 
+        /// specified index to the last element.
+        /// </summary>
+        /// <param name="startIndex">The zero-based starting index of the search.</param>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The zero-based index of the first occurrence of an element that matches the conditions defined
+        ///     by <paramref name="match"/> if found; otherwise, -1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        /// </exception>
+        public int FindIndex(int startIndex, Func<T, bool> match)
+        {
+            return this.InnerList.FindIndex(startIndex, ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+        /// index of the first occurrence within the range of elements in the <see cref="ReadOnlyList{T}"/> that starts at the 
+        /// specified index and contains the specified number of elements.
+        /// </summary>
+        /// <param name="startIndex">The zero-based starting index of the search.</param>
+        /// <param name="count">The number of elements in the section to search.</param>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The zero-based index of the first occurrence of an element that matches the conditions defined
+        ///     by <paramref name="match"/> if found; otherwise, -1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section of the list.
+        /// </exception>
+        public int FindIndex(int startIndex, int count, Func<T, bool> match)
+        {
+            return this.InnerList.FindIndex(startIndex, count, ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an elements that matches the conditions defined by the specified predicate, and returns the last occurrence within the
+        /// entire <see cref="ReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The last elements that matches the conditions defined by the specified predicate, if found; otherwise, the default value for
+        ///     type <typeparamref name="T"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public T FindLast(Func<T, bool> match)
+        {
+            return this.InnerList.FindLast(ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+        /// lat occurrence within the entire <see cref="ReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The zero-based index of the last occurrence of an element that matches the conditions defined by
+        ///     <paramref name="match"/>, if found; otherwise, -1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        public int FindLastIndex(Func<T, bool> match)
+        {
+            return this.InnerList.FindLastIndex(ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+        /// lat occurrence within the range of elements in the <see cref="ReadOnlyList{T}"/> that extends from the first element to the 
+        /// specified index.
+        /// </summary>
+        /// <param name="startIndex">The zero-based starting index of the backward search.</param>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The zero-based index of the last occurrence of an element that matches the conditions defined by
+        ///     <paramref name="match"/>, if found; otherwise, -1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        /// </exception>
+        public int FindLastIndex(int startIndex, Func<T, bool> match)
+        {
+            return this.InnerList.FindLastIndex(startIndex, ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+        /// lat occurrence within the range of elements in the <see cref="ReadOnlyList{T}"/> that contains the specified number
+        /// of elements and ends at the specified index.
+        /// </summary>
+        /// <param name="startIndex">The zero-based starting index of the backward search.</param>
+        /// <param name="count">The number of elements in the section to search.</param>
+        /// <param name="match">The <see cref="Func{T, TResult}"/> delegate the defines the conditions of the elements to search for.</param>
+        /// <returns>
+        ///     The zero-based index of the last occurrence of an element that matches the conditions defined by
+        ///     <paramref name="match"/>, if found; otherwise, -1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section of the list.
+        /// </exception>
+        public int FindLastIndex(int startIndex, int count, Func<T, bool> match)
+        {
+            return this.InnerList.FindLastIndex(startIndex, count, ToPredicate(match));
+        }
+
+        /// <summary>
+        /// Creates a shallow copy of a range of elements in the source <see cref="ReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="index">The zero-based index at which the range starts.</param>
+        /// <param name="count">The number of elements in the range.</param>
+        /// <returns>A shallow copy of a range of elements in the <see cref="ReadOnlyList{T}"/>.</returns>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        /// </exception>
+        public List<T> GetRange(int index, int count)
+        {
+            return this.InnerList.GetRange(index, count);
+        }
+
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the first occurrence
+        /// within the range of elements in the <see cref="ReadOnlyList{T}"/> that extends from the specified index to the last element.
+        /// </summary>
+        /// <param name="item">
+        ///     The object to locate in the <see cref="ReadOnlyList{T}"/>.  
+        ///     The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <param name="index">The zero-based starting index of the search.  0 (zero) is valid in an empty list.</param>
+        /// <returns>
+        ///     The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in the
+        ///     <see cref="ReadOnlyList{T}"/>, if found; otherwise -1.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        /// </exception>
+        public int IndexOf(T item, int index)
+        {
+            return this.InnerList.IndexOf(item, index);
+        }
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the first occurrence
+        /// within the range of elements in the <see cref="ReadOnlyList{T}"/> that extends from the specified index to the last element.
+        /// </summary>
+        /// <param name="item">
+        ///     The object to locate in the <see cref="ReadOnlyList{T}"/>.  
+        ///     The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <param name="index">The zero-based starting index of the search.  0 (zero) is valid in an empty list.</param>
+        /// <param name="count">The number of elements in the section to search.</param>
+        /// <returns>
+        ///     The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in the
+        ///     <see cref="ReadOnlyList{T}"/>, if found; otherwise -1.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> and <paramref name="count"/> do not specify a vliad section in the list.
+        /// </exception>
+        public int IndexOf(T item, int index, int count)
+        {
+            return this.InnerList.IndexOf(item, index, count);
+        }
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the last occurrence
+        /// within the entire <see cref="ReadOnlyList{T}"/>.
+        /// </summary>
+        /// <param name="item">
+        ///     The object to locate in the <see cref="ReadOnlyList{T}"/>.  
+        ///     The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <returns>
+        ///     The zero-based index of the last occurrence of <paramref name="item"/> within the entire
+        ///     <see cref="ReadOnlyList{T}"/>, if found; otherwise -1.
+        /// </returns>
+        public int LastIndexOf(T item)
+        {
+            return this.InnerList.LastIndexOf(item);
+        }
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the last occurrence
+        /// within the range of elements in the <see cref="ReadOnlyList{T}"/> that extends from the first element to the specified index.
+        /// </summary>
+        /// <param name="item">
+        ///     The object to locate in the <see cref="ReadOnlyList{T}"/>.  
+        ///     The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <param name="index">The zero-based starting index of the backward search.</param>
+        /// <returns>
+        ///     The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in the
+        ///     <see cref="ReadOnlyList{T}"/>, if found; otherwise -1.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        /// </exception>
+        public int LastIndexOf(T item, int index)
+        {
+            return this.InnerList.LastIndexOf(item, index);
+        }
+
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the last occurrence
+        /// within the range of elements in the <see cref="ReadOnlyList{T}"/> that contains the specified number
+        /// of elements and ends at the specified index.
+        /// </summary>
+        /// <param name="item">
+        ///     The object to locate in the <see cref="ReadOnlyList{T}"/>.  
+        ///     The value can be <see langword="null"/> for reference types.
+        /// </param>
+        /// <param name="index">The zero-based starting index of the backward search.</param>
+        /// <param name="count">The number of elements in the section to search.</param>
+        /// <returns>
+        ///     The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in the
+        ///     <see cref="ReadOnlyList{T}"/> that contains <paramref name="count"/> number of elements and ends at
+        ///     <paramref name="index"/>, if found; otherwise, -1;
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is outside the range of valid indexes for the <see cref="ReadOnlyList{T}"/>.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> and <paramref name="count"/> do not specify a vliad section in the list.
+        /// </exception>
+        public int LastIndexOf(T item, int index, int count)
+        {
+            return this.InnerList.LastIndexOf(item, index, count);
+        }
+
+        #endregion
+
+        #region SORTING METHODS
+        /// <summary>
+        /// Reverses the order of the elements in the entire <see cref="ListCollection{T}"/>.
+        /// </summary>
+        public void Reverse()
+        {
+            this.InnerList.Reverse();
+            this.OnReversed();
+        }
+        /// <summary>
+        /// Reverses the order of the elements in the specified range.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range to reverse.</param>
+        /// <param name="count">The number of elements in the range to reverse.</param>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in 
+        ///     the <see cref="ListCollection{T}"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        /// </exception>
+        public void Reverse(int index, int count)
+        {
+            this.InnerList.Reverse(index, count);
+            this.OnReversed(index, count);
+        }
+        /// <summary>
+        /// Sorts the elements in the entire <see cref="ListCollection{T}"/> using the default comparer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///     The default comparer <see cref="Comparer{T}.Default"/> cannot find an implementation of the 
+        ///     <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/> interface for type 
+        ///     <typeparamref name="T"/>.
+        /// </exception>
+        public void Sort()
+        {
+            this.InnerList.Sort();
+            this.OnSorted(Comparer<T>.Default);
+        }
+        /// <summary>
+        /// Sorts the elements in the entire <see cref="ListCollection{T}"/> using the specified comparer.
+        /// </summary>
+        /// <param name="comparer">
+        ///     The <see cref="IComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default comparer
+        ///     <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     The implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+        ///     <paramref name="comparer"/> might not return 0 when comparing an item with itself.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     The default comparer <see cref="Comparer{T}.Default"/> cannot find an implementation of the 
+        ///     <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/> interface for type 
+        ///     <typeparamref name="T"/>.
+        /// </exception>
+        public void Sort(IComparer<T> comparer)
+        {
+            this.InnerList.Sort(comparer);
+            this.OnSorted(comparer);
+        }
+        /// <summary>
+        /// Sorts the elements in a range of elements in <see cref="ListCollection{T}"/> using the specified comparer.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range to sort.</param>
+        /// <param name="count">The length of the range to sort.</param>
+        /// <param name="comparer">
+        ///     The <see cref="IComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to use the default comparer
+        ///     <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="index"/> and <paramref name="count"/> do not specify a valid range in the <see cref="ListCollection{T}"/>.
+        ///     -or-
+        ///     The implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+        ///     <paramref name="comparer"/> might not return 0 when comparing an item with itself.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="count"/> is less than 0.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="Comparer{T}.Default"/> 
+        ///     cannot find an implementation of the <see cref="IComparable{T}"/> generic interface or the <see cref="IComparable"/> 
+        ///     interface for type <typeparamref name="T"/>.
+        /// </exception>
+        public void Sort(int index, int count, IComparer<T> comparer)
+        {
+            this.Sort(index, count, comparer);
+            this.OnSorted(comparer, index, count);
+        }
+
+        #endregion
+
+        #region ENUMERATORS
+        /// <summary>
+        /// Returns an enumerator that iterates through the <see cref="UniqueListBase{T}"/>.
+        /// </summary>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.InnerList.GetEnumerator();
+        }
+        /// <summary>
+        /// Returns an enumerator that iterates through the <see cref="IEnumerable"/>.
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+
+        #region SEARCHABLE LIST INTERFACE METHODS
+        IList<T> ISearchableList<T>.FindAll(Func<T, bool> match)
+        {
+            return this.FindAll(match);
+        }
+        IList<T> ISearchableList<T>.GetRange(int index, int count)
+        {
+            return this.GetRange(index, count);
+        }
+
+        #endregion
+
+        #region EXTRA ILIST METHODS
+        /// <summary>
+        /// Inserts an element into the <see cref="ListCollection{T}"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index at which item should be inserted.</param>
+        /// <param name="item">The object to insert. The value can be <see langword="null"/> for reference types.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> is greater than <see cref="Count"/>.
+        /// </exception>
+        public void Insert(int index, T item)
+        {
+            this.InsertItem(index, item);
+        }
+        /// <summary>
+        /// Removes the element at the specified index of the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> is greater than <see cref="UniqueListBase{T}.Count"/>.
+        /// </exception>
+        public void RemoveAt(int index)
+        {
+            this.RemoveItemAt(index);
+        }
+
+        #endregion
+
+        #region NON-GENERIC ILIST INTERFACE EXPLICITS
+
+        #region EXPLICIT INDEXER
+        object IList.this[int index]
+        {
+            get => this[index];
+            set
+            {
+                this[index] = value is T item
+                    ? item
+                    : throw new NotSupportedException();
+            }
+        }
+
+        #endregion
+
+        #region EXPLICIT PROPERTIES
+        bool IList.IsFixedSize => false;
+        bool ICollection.IsSynchronized => ((ICollection)InnerList).IsSynchronized;
+        object ICollection.SyncRoot => ((ICollection)InnerList).SyncRoot;
+
+        #endregion
+
+        #region EXPLICIT METHODS
+        int IList.Add(object value)
+        {
+            int index = -1;
+            if (value is T item)
+            {
+                this.Add(item);
+                index = this.IndexOf(item);
+            }
+
+            return index;
+        }
+        bool IList.Contains(object value)
+        {
+            return value is T item && this.Contains(item);
+        }
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ((ICollection)InnerList).CopyTo(array, index);
+        }
+        int IList.IndexOf(object value)
+        {
+            return ((IList)this.InnerList).IndexOf(value);
+        }
+        void IList.Insert(int index, object value)
+        {
+            if (value is T item)
+            {
+                this.Insert(index, item);
+            }
+        }
+        void IList.Remove(object value)
+        {
+            if (value is T item)
+            {
+                _ = this.Remove(item);
+            }
+        }
+
+        #endregion
+
+        #endregion
+
+        #region PROTECTED AND OVERRIDABLE METHODS
+        /// <summary>
+        /// Adds an object to the end of the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        /// <param name="item">The object to add.</param>
+        protected virtual void AddItem(T item)
+        {
+            this.InnerList.Add(item);
+        }
+        /// <summary>
+        /// Removes all elements from the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        protected virtual void ClearItems()
+        {
+            this.InnerList.Clear();
+        }
+
+        /// <summary>
+        /// Inserts an elements into the <see cref="ListCollection{T}"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index at which <paramref name="item"/> should be inserted.</param>
+        /// <param name="item">The object to insert.</param>
+        protected virtual bool InsertItem(int index, T item)
+        {
+            try
+            {
+                this.InnerList.Insert(index, item);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        /// <summary>
+        /// Removes the specified element from the <see cref="ListCollection{T}"/>.
+        /// </summary>
+        /// <param name="item">The element to remove.</param>
+        /// <returns>
+        ///     <see langword="true"/> if <paramref name="item"/> is successfully removed; otherwise <see langword="false"/>.
+        ///     This method also returns <see langword="false"/> if <paramref name="item"/> was not found in 
+        ///     the <see cref="ListCollection{T}"/>.
+        /// </returns>
+        protected virtual bool RemoveItem(T item)
+        {
+            return this.InnerList.Remove(item);
+        }
+        /// <summary>
+        /// Removes the element at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        protected virtual bool RemoveItemAt(int index)
+        {
+            try
+            {
+                this.InnerList.RemoveAt(index);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        /// <summary>
+        /// Replaces the element at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to replace.</param>
+        /// <param name="item">The new value for the element at the specified index.</param>
+        protected virtual bool SetItem(int index, T item)
+        {
+            try
+            {
+                this.InnerList[index] = item;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        #region EVENT TRIGGERS
+        /// <summary>
+        /// The method that invokes the <see cref="Reversed"/> event with -1 as the index and count.
+        /// </summary>
+        protected void OnReversed()
+        {
+            this.OnReversed(-1, -1);
+        }
+        /// <summary>
+        /// The method that invoces the <see cref="Reversed"/> event with the specified index and count of
+        /// the Reverse operation.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range to reverse.</param>
+        /// <param name="count">The number of elements in the range to reverse.</param>
+        protected virtual void OnReversed(int index, int count)
+        {
+            this.Reversed?.Invoke(this, new ReversedEventArgs(index, count));
+        }
+        /// <summary>
+        /// The method that invokes the <see cref="Sorted"/> event.
+        /// </summary>
+        /// <param name="index">The zero-based starting index of the range that was sorted.</param>
+        /// <param name="count">The length of the range that was sorted.</param>
+        /// <param name="comparerUsed">
+        ///     The <see cref="IComparer{T}"/> implementation that was used when comparing elements, or <see langword="null"/> to use the default comparer
+        ///     <see cref="Comparer{T}.Default"/>.
+        /// </param>
+        protected virtual void OnSorted(IComparer<T> comparerUsed, int index = -1, int count = -1)
+        {
+            if (null == comparerUsed)
+                comparerUsed = Comparer<T>.Default;
+
+            this.Sorted?.Invoke(this, new SortedEventArgs<T>(index, count, comparerUsed));
+        }
+
+        #endregion
+
+        #endregion
+
+        #region PRIVATE/BACKEND METHODS
+        /// <summary>
+        /// Converts the given <see cref="Func{T, TResult}"/> into a <see cref="Predicate{T}"/> delegate.
+        /// </summary>
+        /// <param name="func">The function to convert.</param>
+        /// <returns>
+        ///     A <see cref="Predicate{T}"/> delegate converted from <paramref name="func"/>.
+        /// </returns>
+        protected static Predicate<T> ToPredicate(Func<T, bool> func)
+        {
+            return new Predicate<T>(func);
+        }
+
+        #endregion
+    }
+}

--- a/MG.Collections/Classes/ManagedKeySortedList.cs
+++ b/MG.Collections/Classes/ManagedKeySortedList.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using MG.Collections.Exceptions;
 using MG.Collections.Extensions;
 
 using Strings = MG.Collections.Properties.Resources;
@@ -750,6 +751,9 @@ namespace MG.Collections
         /// <exception cref="InvalidOperationException">
         ///     <see cref="KeySelector"/> threw an exception.
         /// </exception>
+        /// <exception cref="KeyAlreadyExistsException">
+        ///     The key resulting from <paramref name="value"/> was not unique.
+        /// </exception>
         protected virtual bool AddItem(TValue value)
         {
             TKey key = this.GetKey(value);
@@ -761,7 +765,56 @@ namespace MG.Collections
             catch (ArgumentException e)
             {
                 if (e.GetBaseException().Message.IndexOf("same key already exists") < 0)
-                    throw new ArgumentException("An error occured.  See inner exception for details.", e);
+                    throw new KeyAlreadyExistsException(key, e);
+            }
+            catch (Exception allOther)
+            {
+                throw new InvalidOperationException("An error occured.  See inner exception for details.", allOther);
+            }
+
+            return false;
+        }
+        /// <summary>
+        /// Attemps to add the specified value to the end of the list.  Instead of using the stored function to retrieve the key,
+        /// a separate function is specified from a new, generic input <typeparamref name="TInput"/>.
+        /// </summary>
+        /// <typeparam name="TInput">The generic type to retrieve <typeparamref name="TKey"/> from.</typeparam>
+        /// <param name="input">The input value to retrieve the <typeparamref name="TKey"/> key from.</param>
+        /// <param name="value">The value to store in the <see cref="ManagedKeySortedList{TKey, TValue}"/>.</param>
+        /// <param name="keySelector">The function to retrieve the key from a <typeparamref name="TInput"/> value.</param>
+        /// <returns>
+        ///     <see langword="true"/> if <paramref name="value"/> was added to the list with the 
+        ///     calculated <typeparamref name="TKey"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     Either <paramref name="input"/> or <paramref name="keySelector"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="KeySelector"/> threw an exception.
+        /// </exception>
+        /// <exception cref="KeyAlreadyExistsException">
+        ///     The resulting <typeparamref name="TKey"/> value from <paramref name="keySelector"/> and <paramref name="input"/>
+        ///     is not unique.
+        /// </exception>
+        protected virtual bool AddItem<TInput>(TInput input, TValue value, Func<TInput, TKey> keySelector)
+        {
+            if (null == input)
+                throw new ArgumentNullException(nameof(input));
+
+            if (null == keySelector)
+                throw new ArgumentNullException(nameof(keySelector));
+
+            TKey key = keySelector(input);
+
+            try
+            {
+                InnerList.Add(key, value);
+                return true;
+            }
+            catch (ArgumentException e)
+            {
+                if (e.GetBaseException().Message.IndexOf("same key already exists") < 0)
+                    throw new KeyAlreadyExistsException(key, e);
             }
             catch (Exception allOther)
             {
@@ -789,7 +842,7 @@ namespace MG.Collections
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
-        ///     The <see cref="KeySelector"/> threw an <see cref="Exception"/> when fed
+        ///     The <see cref="KeySelector"/> threw an <see cref="Exception"/> when supplied
         ///     <paramref name="value"/>.
         /// </exception>
         /// <exception cref="KeyNotFoundException"><paramref name="key"/> was not found in the <see cref="ManagedKeySortedList{TKey, TValue}"/>.</exception>

--- a/MG.Collections/Classes/UniqueList.cs
+++ b/MG.Collections/Classes/UniqueList.cs
@@ -119,7 +119,7 @@ namespace MG.Collections
         ///     <paramref name="collection"/> will be enumerated for uniqueness according to the provided 
         ///     <see cref="IEqualityComparer{T}"/>.
         ///     
-        ///     If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+        ///     If <paramref name="collection"/> is null, no exception is thrown, and, instead, an empty
         ///     <see cref="UniqueList{T}"/> instance is initialized.
         /// </remarks>
         /// <param name="collection">
@@ -146,10 +146,29 @@ namespace MG.Collections
         }
 
         #region EXTRA ILIST METHODS
+        /// <summary>
+        /// Inserts an element into the <see cref="UniqueList{T}"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index at which item should be inserted.</param>
+        /// <param name="item">The object to insert. The value can be <see langword="null"/> for reference types.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> is greater than <see cref="UniqueListBase{T}.Count"/>.
+        /// </exception>
         public void Insert(int index, T item)
         {
             this.InsertItem(index, item);
         }
+        /// <summary>
+        /// Removes the element at the specified index of the <see cref="UniqueList{T}"/>.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///     <paramref name="index"/> is less than 0.
+        ///     -or-
+        ///     <paramref name="index"/> is greater than <see cref="UniqueListBase{T}.Count"/>.
+        /// </exception>
         public void RemoveAt(int index)
         {
             this.RemoveItemAt(index);

--- a/MG.Collections/Classes/UniqueListBase.cs
+++ b/MG.Collections/Classes/UniqueListBase.cs
@@ -698,7 +698,7 @@ namespace MG.Collections
         /// </remarks>
         /// <param name="index">The negative or positive index value.</param>
         /// <returns>
-        ///     The element of type <typeparamref name="TItem"/> at the specified proper index position; otherwise, 
+        ///     The element of type <typeparamref name="T"/> at the specified proper index position; otherwise, 
         ///     if the index is determined to be out-of-range, then the default value of <typeparamref name="T"/>.
         /// </returns>
         protected virtual T GetByIndex(int index)

--- a/MG.Collections/Events/ReversedEvent.cs
+++ b/MG.Collections/Events/ReversedEvent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MG.Collections.Events
+{
+    public delegate void ReversedEventHandler(object sender, ReversedEventArgs e);
+    public class ReversedEventArgs : EventArgs
+    {
+        public int Index { get; }
+        public int Count { get; }
+
+        public ReversedEventArgs()
+            : this(-1, -1)
+        {
+        }
+
+        public ReversedEventArgs(int index, int count)
+            : base()
+        {
+            this.Index = index;
+            this.Count = count;
+        }
+    }
+}

--- a/MG.Collections/Events/SortedEvent.cs
+++ b/MG.Collections/Events/SortedEvent.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MG.Collections.Events
+{
+    public delegate void SortedEventHandler<T>(object sender, SortedEventArgs<T> e);
+    public class SortedEventArgs<T> : EventArgs
+    {
+        /// <summary>
+        /// The comparer used to sort the list.
+        /// </summary>
+        public IComparer<T> Comparer { get; }
+
+        public int Index { get; } = -1;
+        public int Count { get; } = -1;
+
+        public SortedEventArgs()
+            : base()
+        {
+        }
+
+        public SortedEventArgs(IComparer<T> comparer)
+        {
+            this.Comparer = comparer;
+        }
+
+        public SortedEventArgs(int index, int count, IComparer<T> comparer)
+            : this(comparer)
+        {
+            this.Index = index;
+            this.Count = count;
+        }
+    }
+}

--- a/MG.Collections/Exceptions/FormattedException.cs
+++ b/MG.Collections/Exceptions/FormattedException.cs
@@ -3,6 +3,9 @@ using System.Globalization;
 
 namespace MG.Collections.Exceptions
 {
+    /// <summary>
+    /// An <see langword="abstract"/> exception class that provides a formatted base for message with arguments.
+    /// </summary>
     public abstract class FormattedException : Exception
     {
         protected const string WithMessage = "{0}: {1}";

--- a/MG.Collections/Exceptions/KeyAlreadyExistsException.cs
+++ b/MG.Collections/Exceptions/KeyAlreadyExistsException.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace MG.Collections.Exceptions
+{
+    /// <summary>
+    /// An exception thrown when an attempt to add a key to a unique list or dictionary that already exists.
+    /// </summary>
+    public class KeyAlreadyExistsException : FormattedException
+    {
+        private const string DEF_MSG = "The specified key already exists";
+        private const string DEF_MSG_2 = "The specified key, '{0}', already exists";
+
+        public object Key { get; }
+
+        public KeyAlreadyExistsException()
+            : base(DEF_MSG)
+        {
+        }
+        public KeyAlreadyExistsException(Exception innerException)
+            : base(innerException, DEF_MSG)
+        {
+        }
+        public KeyAlreadyExistsException(object key)
+            : base(DEF_MSG_2, key.ToString())
+        {
+            this.Key = key;
+        }
+        public KeyAlreadyExistsException(object key, Exception innerException)
+            : base(innerException, DEF_MSG_2, key.ToString())
+        {
+        }
+    }
+}

--- a/MG.Collections/Interfaces/IReadOnlySortableList.cs
+++ b/MG.Collections/Interfaces/IReadOnlySortableList.cs
@@ -29,8 +29,8 @@ namespace MG.Collections
         /// Sorts the elements in the entire <see cref="IReadOnlySortableList{T}"/> using the specified comparer.
         /// </summary>
         /// <param name="comparer">
-        ///     The <see cref="IComparer{T}"/> implementation to use when comparing elements, or null to use the default comparer
-        ///     <see cref="Comparer{T}.Default"/>.
+        ///     The <see cref="IComparer{T}"/> implementation to use when comparing elements, or <see langword="null"/> to 
+        ///     use the default comparer <see cref="Comparer{T}.Default"/>.
         /// </param>
         void Sort(IComparer<T> comparer);
         /// <summary>

--- a/MG.Collections/MG.Collections.csproj
+++ b/MG.Collections/MG.Collections.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;netframework4.6.2</TargetFrameworks>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
-    <FileVersion>1.0.1</FileVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+    <FileVersion>1.0.2</FileVersion>
     <Company>Yevrag35, LLC.</Company>
     <Authors>Mike Garvey</Authors>
     <Description>A library consisting of specialized collection classes.</Description>

--- a/MG.Collections/MG.Collections.xml
+++ b/MG.Collections/MG.Collections.xml
@@ -4,6 +4,842 @@
         <name>MG.Collections</name>
     </assembly>
     <members>
+        <member name="T:MG.Collections.Classes.ListCollection`1">
+            <summary>
+            An indentical implementation to <see cref="T:System.Collections.Generic.List`1"/> but with the ability for derived classes to override
+            the Add, Insert, Set, and Remove methods.  Similar to the way <see cref="T:System.Collections.ObjectModel.Collection`1"/>
+            allows.
+            </summary>
+            <typeparam name="T">The type of elements in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.</typeparam>
+        </member>
+        <member name="E:MG.Collections.Classes.ListCollection`1.Reversed">
+            <summary>
+            An event that occurs when the <see cref="T:MG.Collections.Classes.ListCollection`1"/> is reversed through the 'Reverse' methods.
+            </summary>
+        </member>
+        <member name="E:MG.Collections.Classes.ListCollection`1.Sorted">
+            <summary>
+            An event that occurs when the <see cref="T:MG.Collections.Classes.ListCollection`1"/> is sorted through the 'Sort' methods.
+            </summary>
+        </member>
+        <member name="P:MG.Collections.Classes.ListCollection`1.Item(System.Int32)">
+            <summary>
+            Gets or sets the element at the specified index.
+            </summary>
+            <param name="index">The index value for zero-based indexing.</param>
+            <returns>
+                The element at the specified index.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0
+                -or-
+                <paramref name="index"/> is greater than or equal than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+        </member>
+        <member name="P:MG.Collections.Classes.ListCollection`1.Capacity">
+            <summary>
+            Gets or sets the total number of elements the internal data structure can hold without resizing.
+            </summary>
+            <returns>
+                The number of elements that the <see cref="T:MG.Collections.Classes.ListCollection`1"/> can contain before resizing is required.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <see cref="P:MG.Collections.Classes.ListCollection`1.Capacity"/> is set to a value that is less than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+            <exception cref="T:System.OutOfMemoryException">
+                There is not enough memory available on the system.
+            </exception>
+        </member>
+        <member name="P:MG.Collections.Classes.ListCollection`1.Count">
+            <summary>
+            Gets the number of elements contained in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <returns>
+                The number of elements contained in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor">
+            <summary>
+            The default constructor.  Initializes an empty <see cref="T:MG.Collections.Classes.ListCollection`1"/> with the default capacity.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor(System.Int32)">
+            <summary>
+            Initializes an empty <see cref="T:MG.Collections.Classes.ListCollection`1"/> with the specified capacity.
+            </summary>
+            <param name="capacity">The number of elements that the new collection can initially store.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor(System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Initializes a new <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance that contains elements copied from the specified
+            collection and has sufficient capacity to accomodate the number of elements copied.
+            </summary>
+            <remarks>
+                If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance is initialized.
+            </remarks>
+            <param name="items">
+                The collection whose elements will be copied to the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.#ctor(System.Collections.Generic.IEnumerable{`0},System.Boolean)">
+            <summary>
+            Initializes a new <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance that contains elements copied from the specified
+            collection and has sufficient capacity to accomodate the number of elements copied.  It also provides an option to
+            initialize the collection even if <paramref name="items"/> is <see langword="null"/>.
+            </summary>
+            <remarks>
+                If <paramref name="items"/> is null and <paramref name="initializeIfNull"/> is 
+                <see langword="false"/>, an <see cref="T:System.ArgumentNullException"/> exception is thrown.  If, however,
+                <paramref name="initializeIfNull"/> is <see langword="true"/>, an empty
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/> instance is initialized with the default capacity instead.
+            </remarks>
+            <param name="items">
+                The collection whose elements will be copied to the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </param>
+            <param name="initializeIfNull">
+                Indicates that the <see cref="T:MG.Collections.Classes.ListCollection`1"/> should be initialized even if <paramref name="items"/>
+                is found to be <see langword="null"/>.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="initializeIfNull"/> is <see langword="false"/> and
+                <paramref name="items"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Add(`0)">
+            <summary>
+            Adds an item to the end of the collection.
+            </summary>
+            <param name="item">The object to be added to the end of the collection.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Clear">
+            <summary>
+            Removes all elements from the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Contains(`0)">
+            <summary>
+            Determines whether an element is in the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+            <param name="item">
+            The object to locate in the <see cref="T:MG.Collections.UniqueListBase`1"/>.  The value can be null for reference types.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.CopyTo(`0[],System.Int32)">
+            <summary>
+            Copies the entire <see cref="T:MG.Collections.UniqueListBase`1"/> to a compatible one-dimensional array, starting at
+            the specified index of the target array.
+            </summary>
+            <param name="array">
+            The one-dimensional array that is the destination of the elements copied from
+            <see cref="T:MG.Collections.UniqueListBase`1"/>.  The array must have zero-based indexing.
+            </param>
+            <param name="arrayIndex">The zero-based index in the target array at which copying begins.</param>
+            <exception cref="T:System.ArgumentNullException"/>
+            <exception cref="T:System.ArgumentOutOfRangeException"/>
+            <exception cref="T:System.ArgumentException"/>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.IndexOf(`0)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the first occurrence
+            within the entire <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+            <param name="item">The object to locate in the <see cref="T:MG.Collections.UniqueListBase`1"/>.  The value can be null for reference types.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Remove(`0)">
+            <summary>
+            Removes the specific object from the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+            <param name="item">
+                The object to remove from the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ToArray">
+            <summary>
+            Copies the elements of the <see cref="T:MG.Collections.UniqueList`1"/> to a new array.
+            </summary>
+            <returns>
+                An array containing copies of the elements of the <see cref="T:MG.Collections.UniqueList`1"/>.  If the list contains no elements, 
+                an empty array is returned.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.TrueForAll(System.Func{`0,System.Boolean})">
+            <summary>
+            Determines whether every element in the <see cref="T:MG.Collections.ReadOnlyList`1"/> matches the conditions
+            defined by the specified predicate.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate that defines the conditions to check against the elements.</param>
+            <returns>
+                <see langword="true"/>: if every element in the list matches the conditions defined; 
+                otherwise, <see langword="false"/>.
+                If the list has no elements, the return value is <see langword="true"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.BinarySearch(`0)">
+            <summary>
+            Searches the entire sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/> for an element using the default comparer
+            and returns the zero-based index of the element.
+            </summary>
+            <param name="item">The object to locate.  The value can be <see langword="null"/> for reference types.</param>
+            <returns>
+                The zero-based index of <paramref name="item"/> in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>,
+                if <paramref name="item"/> is found; otherwise, a negative number that is the bitwise complement
+                of the index of the next element that is larger than <paramref name="item"/> or, if there is no
+                larger element, the bitwise complement of <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                The default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find
+                an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.BinarySearch(`0,System.Collections.Generic.IComparer{`0})">
+            <summary>
+            Searches the entire sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/> for an element using the specified comparer and
+            returns the zero-based index of the elements.
+            </summary>
+            <param name="item">The object to locate.  The value can be <see langword="null"/> for reference types.</param>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements.
+                -or-
+                <see langword="null"/> to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <returns>
+                The zero-based index of <paramref name="item"/> in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>, if
+                <paramref name="item"/> is found; otherwise, a negative number that is bitwise complement of the index
+                of the next element that is larger than <paramref name="item"/> or, if there is no larger element, the
+                bitwise complement of <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </returns>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> 
+                cannot find an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.BinarySearch(System.Int32,System.Int32,`0,System.Collections.Generic.IComparer{`0})">
+            <summary>
+                Searches a range of elements in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>
+                for an element using the specified comparer and returns the zero-based index
+                of the element.
+            </summary>
+            <param name="index">The zero-based starting index of the range to search.</param>
+            <param name="count">The length of the range to search.</param>
+            <param name="item">The object to locate. The value can be <see langword="null"/> for reference types.</param>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements.
+                -or-
+                <see langword="null"/> to use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <returns>
+                The zero-based index of <paramref name="item"/> in the sorted <see cref="T:MG.Collections.Classes.ListCollection`1"/>, if
+                <paramref name="item"/> is found; otherwise, a negative number that is bitwise complement of the index
+                of the next element that is larger than <paramref name="item"/> or, if there is no larger element, the
+                bitwise complement of <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </returns>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range in the
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> 
+                cannot find an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/>
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ConvertAll``1(System.Converter{`0,``0})">
+            <summary>
+            Converts the elements in the current <see cref="T:MG.Collections.Classes.ListCollection`1"/> to another
+                type, and returns a list containing the converted elements.
+            </summary>
+            <typeparam name="TOutput">
+                The type of the elements of the target array.
+            </typeparam>
+            <param name="converter">
+                A <see cref="T:System.Converter`2"/> delegate that converts each element from one type
+                to another type.
+            </param>
+            <returns>
+                A <see cref="T:System.Collections.Generic.List`1"/> of the target type containing the converted elements from the
+                current <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="converter"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.CopyTo(`0[])">
+            <summary>
+            Copies the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/> to a compatible one-dimensional array, starting at the
+            beginning of the target array.
+            </summary>
+            <param name="array">
+                The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/>.  The <see cref="T:System.Array"/> must have zero-based indexing.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                The number of elements in the source <see cref="T:MG.Collections.Classes.ListCollection`1"/> is greater than the number of
+                elements that the destination array can contain.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="array"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.CopyTo(System.Int32,`0[],System.Int32,System.Int32)">
+            <summary>
+            Copies a range of elements from the <see cref="T:MG.Collections.Classes.ListCollection`1"/> to a compatible one-dimensional array,
+            starting at the specified index of the target array.
+            </summary>
+            <param name="index">
+                The zero-based index in the source <see cref="T:MG.Collections.Classes.ListCollection`1"/> at which copying begins.
+            </param>
+            <param name="array">
+                The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from
+                <see cref="T:MG.Collections.Classes.ListCollection`1"/>.  The <see cref="T:System.Array"/> must have zero-based indexing.
+            </param>
+            <param name="arrayIndex">
+                The zero-based index in <paramref name="array"/> at which copying begins.
+            </param>
+            <param name="count">The number of elements to copy.</param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> is equal to or greater than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/> of the source <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+                -or-
+                The number of elements from <paramref name="index"/> to the end of the source <see cref="T:MG.Collections.Classes.ListCollection`1"/> is greater
+                than the available space from <paramref name="arrayIndex"/> to the end of the destination array.
+            </exception>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="array"/> is <see langword="null"/>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ForEach(System.Action{`0})">
+            <summary>
+            Performs the specified action on each element of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="action">
+                The <see cref="T:System.Action`1"/> delegate to perform on each element of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="action"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.InvalidOperationException">
+                An element in the collection has been modified.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.InsertRange(System.Int32,System.Collections.Generic.IEnumerable{`0})">
+            <summary>
+            Inserts the elements of a collection into the <see cref="T:MG.Collections.Classes.ListCollection`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which the new elements should be inserted.</param>
+            <param name="collection">
+                The collection whose elements should be insert into the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.  The collection
+                itself cannot be <see langword="null"/>, but it can contain elements that are <see langword="null"/>, if 
+                type <typeparamref name="T"/> is a reference type.
+            </param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveAll(System.Func{`0,System.Boolean})">
+            <summary>
+            Removes all the elements that match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">
+                The <see cref="T:System.Func`2"/> delegate that defines the conditions of the elements to remove.
+            </param>
+            <returns>
+                The number of elements removed from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                <paramref name="match"/> is <see langword="null"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveRange(System.Int32,System.Int32)">
+            <summary>
+            Removes a range of elements from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="index">The zero-based starting index of the range of elements to remove.</param>
+            <param name="count">The number of elements to remove.</param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements
+                in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.TrimExcess">
+            <summary>
+            Sets the capacity to the actual number of elements in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>,
+            if that number is less than a threshold value.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Exists(System.Func{`0,System.Boolean})">
+            <summary>
+                Determines whether the <see cref="T:MG.Collections.ReadOnlyList`1"/> contains elements that
+                match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">
+                The <see cref="T:System.Func`2"/> delegate that defines the conditions of the 
+                elements to search for.
+            </param>
+            <returns>
+            <see langword="true"/>:
+                if the <see cref="T:MG.Collections.ReadOnlyList`1"/> contains one or more elements that
+                <paramref name="match"/> defined.
+            <see langword="false"/>:
+                otherwise.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Find(System.Func{`0,System.Boolean})">
+            <summary>
+                Searches for an element that matches the conditions defined by the specified
+                predicate, and returns the first occurrence within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">
+                The <see cref="T:System.Func`2"/> delegate that defines the conditions of the
+                elements to search for.
+            </param>
+            <returns>
+                The first element that matches the conditions if found; otherwise the default value for <typeparamref name="T"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindAll(System.Func{`0,System.Boolean})">
+            <summary>
+            Retrieves all of the elements that match the conditions defined by the specified predicate.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                An <see cref="T:System.Collections.Generic.List`1"/> containing all of the elements that match the conditions if found; 
+                otherwise, an empty list.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindIndex(System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+            index of the first occurrence within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the first occurrence of an element that matches the conditions defined
+                by <paramref name="match"/> if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindIndex(System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+            index of the first occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the 
+            specified index to the last element.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the first occurrence of an element that matches the conditions defined
+                by <paramref name="match"/> if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindIndex(System.Int32,System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an element that match the conditions defined by the specified predicate, and returns the zero-based
+            index of the first occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that starts at the 
+            specified index and contains the specified number of elements.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the search.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the first occurrence of an element that matches the conditions defined
+                by <paramref name="match"/> if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section of the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLast(System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the last occurrence within the
+            entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The last elements that matches the conditions defined by the specified predicate, if found; otherwise, the default value for
+                type <typeparamref name="T"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLastIndex(System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+            lat occurrence within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the last occurrence of an element that matches the conditions defined by
+                <paramref name="match"/>, if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLastIndex(System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+            lat occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the first element to the 
+            specified index.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the backward search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the last occurrence of an element that matches the conditions defined by
+                <paramref name="match"/>, if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.FindLastIndex(System.Int32,System.Int32,System.Func{`0,System.Boolean})">
+            <summary>
+            Searches for an elements that matches the conditions defined by the specified predicate, and returns the zero-based index of the
+            lat occurrence within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that contains the specified number
+            of elements and ends at the specified index.
+            </summary>
+            <param name="startIndex">The zero-based starting index of the backward search.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <param name="match">The <see cref="T:System.Func`2"/> delegate the defines the conditions of the elements to search for.</param>
+            <returns>
+                The zero-based index of the last occurrence of an element that matches the conditions defined by
+                <paramref name="match"/>, if found; otherwise, -1.
+            </returns>
+            <exception cref="T:System.ArgumentNullException"><paramref name="match"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="startIndex"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section of the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.GetRange(System.Int32,System.Int32)">
+            <summary>
+            Creates a shallow copy of a range of elements in the source <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="index">The zero-based index at which the range starts.</param>
+            <param name="count">The number of elements in the range.</param>
+            <returns>A shallow copy of a range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.</returns>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.IndexOf(`0,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the first occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the specified index to the last element.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the search.  0 (zero) is valid in an empty list.</param>
+            <returns>
+                The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.IndexOf(`0,System.Int32,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the first occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the specified index to the last element.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the search.  0 (zero) is valid in an empty list.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <returns>
+                The zero-based index of the first occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="index"/> and <paramref name="count"/> do not specify a vliad section in the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.LastIndexOf(`0)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the last occurrence
+            within the entire <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <returns>
+                The zero-based index of the last occurrence of <paramref name="item"/> within the entire
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.LastIndexOf(`0,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the last occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that extends from the first element to the specified index.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the backward search.</param>
+            <returns>
+                The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/>, if found; otherwise -1.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.LastIndexOf(`0,System.Int32,System.Int32)">
+            <summary>
+            Searches for the specified object and returns the zero-based index of the last occurrence
+            within the range of elements in the <see cref="T:MG.Collections.ReadOnlyList`1"/> that contains the specified number
+            of elements and ends at the specified index.
+            </summary>
+            <param name="item">
+                The object to locate in the <see cref="T:MG.Collections.ReadOnlyList`1"/>.  
+                The value can be <see langword="null"/> for reference types.
+            </param>
+            <param name="index">The zero-based starting index of the backward search.</param>
+            <param name="count">The number of elements in the section to search.</param>
+            <returns>
+                The zero-based index of the last occurrence of <paramref name="item"/> within the range of elements in the
+                <see cref="T:MG.Collections.ReadOnlyList`1"/> that contains <paramref name="count"/> number of elements and ends at
+                <paramref name="index"/>, if found; otherwise, -1;
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is outside the range of valid indexes for the <see cref="T:MG.Collections.ReadOnlyList`1"/>.
+                -or-
+                <paramref name="count"/> is less than 0.
+                -or-
+                <paramref name="index"/> and <paramref name="count"/> do not specify a vliad section in the list.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Reverse">
+            <summary>
+            Reverses the order of the elements in the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Reverse(System.Int32,System.Int32)">
+            <summary>
+            Reverses the order of the elements in the specified range.
+            </summary>
+            <param name="index">The zero-based starting index of the range to reverse.</param>
+            <param name="count">The number of elements in the range to reverse.</param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not denote a valid range of elements in 
+                the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Sort">
+            <summary>
+            Sorts the elements in the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/> using the default comparer.
+            </summary>
+            <exception cref="T:System.InvalidOperationException">
+                The default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the 
+                <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> interface for type 
+                <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Sort(System.Collections.Generic.IComparer{`0})">
+            <summary>
+            Sorts the elements in the entire <see cref="T:MG.Collections.Classes.ListCollection`1"/> using the specified comparer.
+            </summary>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/> to use the default comparer
+                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                The implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+                <paramref name="comparer"/> might not return 0 when comparing an item with itself.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                The default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> cannot find an implementation of the 
+                <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> interface for type 
+                <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Sort(System.Int32,System.Int32,System.Collections.Generic.IComparer{`0})">
+            <summary>
+            Sorts the elements in a range of elements in <see cref="T:MG.Collections.Classes.ListCollection`1"/> using the specified comparer.
+            </summary>
+            <param name="index">The zero-based starting index of the range to sort.</param>
+            <param name="count">The length of the range to sort.</param>
+            <param name="comparer">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/> to use the default comparer
+                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+            <exception cref="T:System.ArgumentException">
+                <paramref name="index"/> and <paramref name="count"/> do not specify a valid range in the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+                -or-
+                The implementation of <paramref name="comparer"/> caused an error during the sort. For example,
+                <paramref name="comparer"/> might not return 0 when comparing an item with itself.
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="count"/> is less than 0.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <paramref name="comparer"/> is <see langword="null"/>, and the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/> 
+                cannot find an implementation of the <see cref="T:System.IComparable`1"/> generic interface or the <see cref="T:System.IComparable"/> 
+                interface for type <typeparamref name="T"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.GetEnumerator">
+            <summary>
+            Returns an enumerator that iterates through the <see cref="T:MG.Collections.UniqueListBase`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.System#Collections#IEnumerable#GetEnumerator">
+            <summary>
+            Returns an enumerator that iterates through the <see cref="T:System.Collections.IEnumerable"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.Insert(System.Int32,`0)">
+            <summary>
+            Inserts an element into the <see cref="T:MG.Collections.Classes.ListCollection`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which item should be inserted.</param>
+            <param name="item">The object to insert. The value can be <see langword="null"/> for reference types.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.Classes.ListCollection`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.AddItem(`0)">
+            <summary>
+            Adds an object to the end of the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="item">The object to add.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ClearItems">
+            <summary>
+            Removes all elements from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.InsertItem(System.Int32,`0)">
+            <summary>
+            Inserts an elements into the <see cref="T:MG.Collections.Classes.ListCollection`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which <paramref name="item"/> should be inserted.</param>
+            <param name="item">The object to insert.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveItem(`0)">
+            <summary>
+            Removes the specified element from the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </summary>
+            <param name="item">The element to remove.</param>
+            <returns>
+                <see langword="true"/> if <paramref name="item"/> is successfully removed; otherwise <see langword="false"/>.
+                This method also returns <see langword="false"/> if <paramref name="item"/> was not found in 
+                the <see cref="T:MG.Collections.Classes.ListCollection`1"/>.
+            </returns>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.RemoveItemAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.SetItem(System.Int32,`0)">
+            <summary>
+            Replaces the element at the specified index.
+            </summary>
+            <param name="index">The zero-based index of the element to replace.</param>
+            <param name="item">The new value for the element at the specified index.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.OnReversed">
+            <summary>
+            The method that invokes the <see cref="E:MG.Collections.Classes.ListCollection`1.Reversed"/> event with -1 as the index and count.
+            </summary>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.OnReversed(System.Int32,System.Int32)">
+            <summary>
+            The method that invoces the <see cref="E:MG.Collections.Classes.ListCollection`1.Reversed"/> event with the specified index and count of
+            the Reverse operation.
+            </summary>
+            <param name="index">The zero-based starting index of the range to reverse.</param>
+            <param name="count">The number of elements in the range to reverse.</param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.OnSorted(System.Collections.Generic.IComparer{`0},System.Int32,System.Int32)">
+            <summary>
+            The method that invokes the <see cref="E:MG.Collections.Classes.ListCollection`1.Sorted"/> event.
+            </summary>
+            <param name="index">The zero-based starting index of the range that was sorted.</param>
+            <param name="count">The length of the range that was sorted.</param>
+            <param name="comparerUsed">
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation that was used when comparing elements, or <see langword="null"/> to use the default comparer
+                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+            </param>
+        </member>
+        <member name="M:MG.Collections.Classes.ListCollection`1.ToPredicate(System.Func{`0,System.Boolean})">
+            <summary>
+            Converts the given <see cref="T:System.Func`2"/> into a <see cref="T:System.Predicate`1"/> delegate.
+            </summary>
+            <param name="func">The function to convert.</param>
+            <returns>
+                A <see cref="T:System.Predicate`1"/> delegate converted from <paramref name="func"/>.
+            </returns>
+        </member>
         <member name="T:MG.Collections.ManagedKeySortedList`2">
             <summary>
             A <see cref="T:System.Collections.Generic.SortedList`2"/> class where <typeparamref name="TKey"/> is automatically retrieved with 
@@ -376,6 +1212,33 @@
             <exception cref="T:System.InvalidOperationException">
                 <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an exception.
             </exception>
+            <exception cref="T:MG.Collections.Exceptions.KeyAlreadyExistsException">
+                The key resulting from <paramref name="value"/> was not unique.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.ManagedKeySortedList`2.AddItem``1(``0,`1,System.Func{``0,`0})">
+            <summary>
+            Attemps to add the specified value to the end of the list.  Instead of using the stored function to retrieve the key,
+            a separate function is specified from a new, generic input <typeparamref name="TInput"/>.
+            </summary>
+            <typeparam name="TInput">The generic type to retrieve <typeparamref name="TKey"/> from.</typeparam>
+            <param name="input">The input value to retrieve the <typeparamref name="TKey"/> key from.</param>
+            <param name="value">The value to store in the <see cref="T:MG.Collections.ManagedKeySortedList`2"/>.</param>
+            <param name="keySelector">The function to retrieve the key from a <typeparamref name="TInput"/> value.</param>
+            <returns>
+                <see langword="true"/> if <paramref name="value"/> was added to the list with the 
+                calculated <typeparamref name="TKey"/>; otherwise, <see langword="false"/>.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+                Either <paramref name="input"/> or <paramref name="keySelector"/> is <see langword="null"/>.
+            </exception>
+            <exception cref="T:System.InvalidOperationException">
+                <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an exception.
+            </exception>
+            <exception cref="T:MG.Collections.Exceptions.KeyAlreadyExistsException">
+                The resulting <typeparamref name="TKey"/> value from <paramref name="keySelector"/> and <paramref name="input"/>
+                is not unique.
+            </exception>
         </member>
         <member name="M:MG.Collections.ManagedKeySortedList`2.ClearItems">
             <summary>
@@ -395,7 +1258,7 @@
             </returns>
             <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
             <exception cref="T:System.InvalidOperationException">
-                The <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an <see cref="T:System.Exception"/> when fed
+                The <see cref="P:MG.Collections.ManagedKeySortedList`2.KeySelector"/> threw an <see cref="T:System.Exception"/> when supplied
                 <paramref name="value"/>.
             </exception>
             <exception cref="T:System.Collections.Generic.KeyNotFoundException"><paramref name="key"/> was not found in the <see cref="T:MG.Collections.ManagedKeySortedList`2"/>.</exception>
@@ -1193,7 +2056,7 @@
                 <paramref name="collection"/> will be enumerated for uniqueness according to the provided 
                 <see cref="T:System.Collections.Generic.IEqualityComparer`1"/>.
                 
-                If <paramref name="items"/> is null, no exception is thrown, and, instead, an empty
+                If <paramref name="collection"/> is null, no exception is thrown, and, instead, an empty
                 <see cref="T:MG.Collections.UniqueList`1"/> instance is initialized.
             </remarks>
             <param name="collection">
@@ -1203,6 +2066,29 @@
             <param name="equalityComparer">
                 The equality comparer that determines whether an element is unique.
             </param>
+        </member>
+        <member name="M:MG.Collections.UniqueList`1.Insert(System.Int32,`0)">
+            <summary>
+            Inserts an element into the <see cref="T:MG.Collections.UniqueList`1"/> at the specified index.
+            </summary>
+            <param name="index">The zero-based index at which item should be inserted.</param>
+            <param name="item">The object to insert. The value can be <see langword="null"/> for reference types.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
+        </member>
+        <member name="M:MG.Collections.UniqueList`1.RemoveAt(System.Int32)">
+            <summary>
+            Removes the element at the specified index of the <see cref="T:MG.Collections.UniqueList`1"/>.
+            </summary>
+            <param name="index">The zero-based index of the element to remove.</param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+                <paramref name="index"/> is less than 0.
+                -or-
+                <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
+            </exception>
         </member>
         <member name="T:MG.Collections.UniqueListBase`1">
             <summary>
@@ -1738,7 +2624,7 @@
             </remarks>
             <param name="index">The negative or positive index value.</param>
             <returns>
-                The element of type <typeparamref name="TItem"/> at the specified proper index position; otherwise, 
+                The element of type <typeparamref name="T"/> at the specified proper index position; otherwise, 
                 if the index is determined to be out-of-range, then the default value of <typeparamref name="T"/>.
             </returns>
         </member>
@@ -1782,6 +2668,21 @@
                 -or
                 <paramref name="index"/> is greater than <see cref="P:MG.Collections.UniqueListBase`1.Count"/>.
             </exception>
+        </member>
+        <member name="P:MG.Collections.Events.SortedEventArgs`1.Comparer">
+            <summary>
+            The comparer used to sort the list.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Exceptions.FormattedException">
+            <summary>
+            An <see langword="abstract"/> exception class that provides a formatted base for message with arguments.
+            </summary>
+        </member>
+        <member name="T:MG.Collections.Exceptions.KeyAlreadyExistsException">
+            <summary>
+            An exception thrown when an attempt to add a key to a unique list or dictionary that already exists.
+            </summary>
         </member>
         <member name="T:MG.Collections.Exceptions.ReadOnlyException">
             <summary>
@@ -2020,8 +2921,8 @@
             Sorts the elements in the entire <see cref="T:MG.Collections.IReadOnlySortableList`1"/> using the specified comparer.
             </summary>
             <param name="comparer">
-                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or null to use the default comparer
-                <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
+                The <see cref="T:System.Collections.Generic.IComparer`1"/> implementation to use when comparing elements, or <see langword="null"/> to 
+                use the default comparer <see cref="P:System.Collections.Generic.Comparer`1.Default"/>.
             </param>
         </member>
         <member name="M:MG.Collections.IReadOnlySortableList`1.Sort(System.Int32,System.Int32,System.Collections.Generic.IComparer{`0})">


### PR DESCRIPTION
* Extra protected overload to 'AddItem' on ManagedKeySortedList
  * This new overload will allow you to add a key from another type that is NOT TValue.

* ListCollection
  * Identical to List but with methods similar to 'System.Collections.ObjectModel.Collection<T>' that allow derived classes to override the Add, Insert, Set, and Remove functionality.

* Split .NETCore3.1 WPF to separate project